### PR TITLE
feat: update gvisor extension after testing

### DIFF
--- a/gvisor/README.md
+++ b/gvisor/README.md
@@ -1,0 +1,53 @@
+# gVisor extension
+
+## Usage
+
+Enable the extension in the machine configuration before installing Talos:
+
+```yaml
+machine:
+  install:
+    extensions:
+      - image: ghcr.io/talos-systems/gvisor:<VERSION>
+```
+
+gVisor requires unprivileged user namespace creation, so Talos default setting
+should be overridden:
+
+```yaml
+machine:
+  sysctls:
+    user.max_user_namespaces: "11255"
+```
+
+> Warning! This disables [KSPP best practices](https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings#sysctls) setting.
+
+## Testing
+
+Apply the following manifest to run nginx pod via gVisor:
+
+```yaml
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+handler: runsc
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-gvisor
+spec:
+  runtimeClassName: gvisor
+  containers:
+  - name: nginx
+    image: nginx
+```
+
+The pod should be up and running:
+
+```bash
+$ kubectl get pods
+NAME           READY   STATUS    RESTARTS   AGE
+nginx-gvisor   1/1     Running   0          40s
+```

--- a/gvisor/gvisor.part
+++ b/gvisor/gvisor.part
@@ -1,2 +1,6 @@
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
   runtime_type = "io.containerd.runsc.v1"
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc.options]
+  TypeUrl = "io.containerd.runsc.v1.options"
+  ConfigPath = "/etc/cri/conf.d/runsc.toml"

--- a/gvisor/manifest.yaml
+++ b/gvisor/manifest.yaml
@@ -7,4 +7,4 @@ metadata:
     This system extension provides gVisor using containerd's runtime handler.
   compatibility:
     talos:
-      version: ">= v1.0.0"
+      version: "> v0.15.0-alpha.1"

--- a/gvisor/pkg.yaml
+++ b/gvisor/pkg.yaml
@@ -48,3 +48,5 @@ finalize:
     to: /
   - from: /pkg/gvisor.part
     to: /rootfs/etc/cri/conf.d/gvisor.part
+  - from: /pkg/runsc.toml
+    to: /rootfs/etc/cri/conf.d/runsc.toml

--- a/gvisor/runsc.toml
+++ b/gvisor/runsc.toml
@@ -1,0 +1,3 @@
+[runsc_config]
+# See https://github.com/talos-systems/extensions/issues/4
+ignore-cgroups = "true"


### PR DESCRIPTION
This extension was tested with Talos, there's one issue with cgroups
which required disabling cgroup support in `runsc`.

Fixed up manifest and added documentation on using the extension.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>