### PR TITLE
chore: bump nvidia drivers to 510.60.02

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -6,7 +6,7 @@ vars:
   TOOLS_IMAGE: ghcr.io/siderolabs/tools:v1.1.0-alpha.0-2-gbfc99ca
   LINUX_FIRMWARE_IMAGE: ghcr.io/siderolabs/linux-firmware:v1.0.0-5-g615d1a0
   NVIDIA_DRIVER_VERSION_MAJOR: 510
-  NVIDIA_DRIVER_VERSION_MINOR: 54
+  NVIDIA_DRIVER_VERSION_MINOR: 60.02
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/extensions

--- a/nvidia-container-toolkit/DEVELOPMENT.md
+++ b/nvidia-container-toolkit/DEVELOPMENT.md
@@ -25,7 +25,8 @@ This is used to create the required NVIDIA device files under `/dev`. This requi
 ## Updating the nvidia driver version
 
 - Update the driver version in `pkgs` repo [here](https://github.com/siderolabs/pkgs/blob/master/nonfree/kmod-nvidia/pkg.yaml)
-- Update the driver version [here](../Pkgfile)
+- Update the driver version [here](../Pkgfile) and [here](./manifest.yaml)
+- Update the driver checksums [here](./nvidia-pkgs/pkg.yaml)
 
 ## Updating the nvidia-container-toolkit version
 

--- a/nvidia-container-toolkit/README.md
+++ b/nvidia-container-toolkit/README.md
@@ -62,22 +62,33 @@ Apply the following manifest to run CUDA pod via nvidia runtime:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: cuda-vector-add
+  name: gpu-operator-test
 spec:
   restartPolicy: OnFailure
   runtimeClassName: nvidia
   containers:
-    - name: cuda-vector-add
-      image: "quay.io/giantswarm/nvidia-gpu-demo:latest"
-      resources:
-        limits:
-          nvidia.com/gpu: 1
+  - name: cuda-vector-add
+    image: "nvidia/samples:vectoradd-cuda11.6.0"
+    resources:
+      limits:
+         nvidia.com/gpu: 1
 ```
 
-The pod should be up and running:
+
+The status can be viewed by running:
 
 ```bash
 ❯ kubectl get pods
 NAME                READY   STATUS      RESTARTS   AGE
-cuda-vector-add     0/1     Completed   0          17m
+gpu-operator-test   0/1     Completed   0          13s
+```
+
+```bash
+❯ kubectl logs gpu-operator-test
+[Vector addition of 50000 elements]
+Copy input data from the host memory to the CUDA device
+CUDA kernel launch with 196 blocks of 256 threads
+Copy output data from the CUDA device to the host memory
+Test PASSED
+Done
 ```

--- a/nvidia-container-toolkit/manifest.yaml
+++ b/nvidia-container-toolkit/manifest.yaml
@@ -2,7 +2,7 @@ version: v1alpha1
 metadata:
   name: nvidia-container-toolkit
   # the first part is the driver version and the second the container-toolkit version
-  version: 510.54-v1.9.0
+  version: 510.60.02-v1.9.0
   author: Andrew Rynhard
   description: |
     This system extension provides nvidia runtime and it's dependencies using NVIDIA's runtime handler.

--- a/nvidia-container-toolkit/nvidia-device-create/15-nvidia-device.rules
+++ b/nvidia-container-toolkit/nvidia-device-create/15-nvidia-device.rules
@@ -4,5 +4,5 @@ ACTION=="add", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/usr/local/bin/ub-devic
 # Create the device node for the nvidia-uvm module
 ACTION=="add", DEVPATH=="/module/nvidia_uvm", SUBSYSTEM=="module", RUN+="/usr/local/bin/ub-device-create"
 
-# https://download.nvidia.com/XFree86/Linux-x86_64/510.54/README/nvidia-persistenced.html
+# https://download.nvidia.com/XFree86/Linux-x86_64/510.60.02/README/nvidia-persistenced.html
 ACTION=="add", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/usr/local/bin/nvidia-persistenced --no-persistence-mode --verbose"

--- a/nvidia-container-toolkit/nvidia-device-create/pkg.yaml
+++ b/nvidia-container-toolkit/nvidia-device-create/pkg.yaml
@@ -1,4 +1,4 @@
-# https://download.nvidia.com/XFree86/Linux-x86_64/510.54/README/faq.html
+# https://download.nvidia.com/XFree86/Linux-x86_64/510.60.02/README/faq.html#devicenodes
 # check the section under NVIDIA-INSTALLER -> How and when are the NVIDIA device files created?
 name: nvidia-device-create
 variant: scratch
@@ -7,11 +7,11 @@ dependencies:
 shell: /bin/bash
 steps:
   - sources:
-      # https://github.com/tseliot/nvidia-graphics-drivers/commit/6b655df8a905f2ea00298d44ad6003f7b51fd37a
-      - url: https://github.com/tseliot/nvidia-graphics-drivers/archive/6b655df8a905f2ea00298d44ad6003f7b51fd37a.tar.gz
+      # https://github.com/tseliot/nvidia-graphics-drivers/commit/0a622008df6a81cf96a7740f958654fafc23f79d
+      - url: https://github.com/tseliot/nvidia-graphics-drivers/archive/0a622008df6a81cf96a7740f958654fafc23f79d.tar.gz
         destination: nvidia-graphics-drivers-build.tar.gz
-        sha256: 48a293271d0f38d0f7029c798bad01cbbe39290a36116fda53503463357b47d9
-        sha512: 764ffba4851ff76d4461da7eefcb818ba36e7fc1d3651643a5501e8fdd1ed459aab647656e297887d8a0c805e825bb27794f7c0952d6896b77415b9f2737ab5f
+        sha256: 5fce931c2a0e67e00d2786f66f412f87be4a7b2103dda98cd5400675a85eda63
+        sha512: f043d0f09272fa99130b22c5b3fa4974d60c6f6a258ea45caa0145ea0737d3d2f43eb6caf40f901dd18e20670fff9d1827adb95f89acde53022eb6bb7ca46371
     env:
       DEBIAN_FRONTEND: noninteractive
     prepare:
@@ -21,7 +21,7 @@ steps:
           libkmod-dev \
           build-essential
 
-        # https://download.nvidia.com/XFree86/Linux-x86_64/510.54/README/faq.html#devicenodes
+        # https://download.nvidia.com/XFree86/Linux-x86_64/510.60.02/README/faq.html#devicenodes
         # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#runfile-verifications
         mkdir nvidia-graphics-drivers-build
 

--- a/nvidia-container-toolkit/nvidia-pkgs/pkg.yaml
+++ b/nvidia-container-toolkit/nvidia-pkgs/pkg.yaml
@@ -11,13 +11,13 @@ steps:
     # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
       - url: https://download.nvidia.com/XFree86/Linux-aarch64/{{ .NVIDIA_DRIVER_VERSION_MAJOR }}.{{ .NVIDIA_DRIVER_VERSION_MINOR }}/NVIDIA-Linux-aarch64-{{ .NVIDIA_DRIVER_VERSION_MAJOR }}.{{ .NVIDIA_DRIVER_VERSION_MINOR }}.run
         destination: nvidia.run
-        sha256: bff7a5640445b3e38b35d9d589b52c7353bb473703b7a5d050aa96aaa35ca896
-        sha512: 9d872748dc0957c0754561582a1984a8f912c345a5e616116edfd86d629efb5674c29723c80ae47d458b23aaec6fc5a71724441dd7e11ba4f5b94f8b04591f81
+        sha256: 931521e4fc8175411f2a232e2d3704f8369c21e530283b4fdc4cacb323acc568
+        sha512: fca54ba6abff197dbce55761a4755e98aebd16a851b54ba072c2a10296eadc7924adc102be6599d16052d94d9a0a4e260a0d63a098e039afe46210c65dfb3b32
     # {{ else }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
       - url: https://download.nvidia.com/XFree86/Linux-x86_64/{{ .NVIDIA_DRIVER_VERSION_MAJOR }}.{{ .NVIDIA_DRIVER_VERSION_MINOR }}/NVIDIA-Linux-x86_64-{{ .NVIDIA_DRIVER_VERSION_MAJOR }}.{{ .NVIDIA_DRIVER_VERSION_MINOR }}.run
         destination: nvidia.run
-        sha256: 4c20deccae3fe347adfd0e6989a306f9024fdadf831adc1e8e60855675335161
-        sha512: 1e65e96c1ae1cccd5cd483f2b65927e3594d28f3774459dfd094530f445f4b0f5368a3b7eebf4970bd2632438cca2cbb93af50a59a3a87a2c13d08ed5155164c
+        sha256: a800dfc0549078fd8c6e8e6780efb8eee87872e6055c7f5f386a4768ce07e003
+        sha512: ccc459bdf5f89a37f79a1831bac8c03980deaa13082b516d5e9c74a49e1aea7f1f6b03304705a95564a390bf0ca38df10b8c8b73e3470a31444dd5ebfd981cfd
     # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
     env:
       DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
Bump NVIDIA drivers to 510.60.02

Ref: https://github.com/siderolabs/pkgs/pull/434

Signed-off-by: Noel Georgi <git@frezbo.dev>