### PR TITLE
chore: use golang.org/x/sys over syscall

### DIFF
--- a/storage/iscsi-tools/iscsid-wrapper/go.mod
+++ b/storage/iscsi-tools/iscsid-wrapper/go.mod
@@ -1,0 +1,5 @@
+module iscsid-wrapper
+
+go 1.18
+
+require golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6

--- a/storage/iscsi-tools/iscsid-wrapper/go.sum
+++ b/storage/iscsi-tools/iscsid-wrapper/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 h1:nonptSpoQ4vQjyraW20DXPAglgQfVnM9ZC6MmNLMR60=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/storage/iscsi-tools/iscsid-wrapper/main.go
+++ b/storage/iscsi-tools/iscsid-wrapper/main.go
@@ -8,7 +8,8 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func main() {
@@ -36,7 +37,7 @@ func main() {
 	}
 
 	log.Println("iscsid-wrapper: completed..., execing into iscsid")
-	if err := syscall.Exec("/usr/local/sbin/iscsid", []string{"iscsid", "-f"}, os.Environ()); err != nil {
+	if err := unix.Exec("/usr/local/sbin/iscsid", []string{"iscsid", "-f"}, os.Environ()); err != nil {
 		log.Fatalf("iscsid: error execing /usr/local/sbin/iscsid %v\n", err)
 	}
 }

--- a/storage/iscsi-tools/iscsid-wrapper/pkg.yaml
+++ b/storage/iscsi-tools/iscsid-wrapper/pkg.yaml
@@ -1,0 +1,21 @@
+name: iscsid-wrapper
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - build:
+    - |
+      export PATH=${PATH}:${TOOLCHAIN}/go/bin
+
+      cp -r /pkg/* .
+
+      CGO_ENABLED=0 go build -o iscsid-wrapper main.go
+    install:
+    - |
+      mkdir -p /rootfs/usr/local/sbin
+      
+      cp iscsid-wrapper /rootfs/usr/local/sbin/iscsid-wrapper
+finalize:
+  - from: /rootfs
+    to: /rootfs

--- a/storage/iscsi-tools/pkg.yaml
+++ b/storage/iscsi-tools/pkg.yaml
@@ -8,19 +8,11 @@ dependencies:
   - stage: open-isns
   - stage: open-iscsi
   - stage: tgt
+  - stage: iscsid-wrapper
 steps:
-  - build:
-    - |
-      cp /pkg/main.go main.go
-
-      export PATH=${PATH}:${TOOLCHAIN}/go/bin
-
-      CGO_ENABLED=0 go build -o iscsid-wrapper main.go
-    install:
+  - install:
     - |
       mkdir -p /rootfs/usr/local/lib/containers/{iscsid,tgtd}
-      
-      cp iscsid-wrapper /rootfs/usr/local/sbin/iscsid-wrapper
 
       sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
 


### PR DESCRIPTION
Use `golang.org/x/sys` over deprecated `syscall` package

Signed-off-by: Noel Georgi <git@frezbo.dev>