### PR TITLE
fix: copy the hello world extension spec to the correct place

### DIFF
--- a/examples/hello-world-service/pkg.yaml
+++ b/examples/hello-world-service/pkg.yaml
@@ -27,4 +27,4 @@ finalize:
   - from: /pkg/manifest.yaml
     to: /
   - from: /pkg/hello-world.yaml
-    to: /rootfs/usr/local/etc/containers
+    to: /rootfs/usr/local/etc/containers/


### PR DESCRIPTION
The hello world extension example copied its spec to the 'containers'
    path as a file instead of copying it into the 'containers' path as a
    directory.