### PR TITLE
chore: stable source date epoch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
+# inital commit time
+# git rev-list --max-parents=0 HEAD
+# git log a46b3f24d158614d582da5e6e7e34b596d10cb8e --pretty=%ct
+SOURCE_DATE_EPOCH ?= "1642703752"
 ARTIFACTS ?= _out/
 OPERATING_SYSTEM := $(shell uname -s | tr "[:upper:]" "[:lower:]")
 GOARCH :=$(shell uname -m | tr '[:upper:]' '[:lower:]')
@@ -24,6 +28,7 @@ COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
 COMMON_ARGS += --build-arg=http_proxy=$(http_proxy)
 COMMON_ARGS += --build-arg=https_proxy=$(https_proxy)
+COMMON_ARGS += --build-arg=SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)
 COMMON_ARGS += --build-arg=TAG=$(TAG)
 
 , := ,

--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.1.0-alpha.0-24-g5b498d8
+  PKGS_VERSION: v1.1.0-alpha.0-46-g1f48da7
   LINUX_FIRMWARE_VERSION: "20220411" # update this when updating PKGS_VERSION above
 
 labels:


### PR DESCRIPTION
Use the timestamp from repo initial commit as `SOURCE_DATE_EPOCH`

Bump to pkgs built with stable [`SOURCE_DATE_EPOCH`](https://github.com/siderolabs/pkgs/pull/489)

Signed-off-by: Noel Georgi <git@frezbo.dev>