### PR TITLE
fix: parsing pidfile with newlines

### DIFF
--- a/nonfree/nvidia-container-toolkit/nvidia-persistenced-wrapper/main.go
+++ b/nonfree/nvidia-container-toolkit/nvidia-persistenced-wrapper/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"io/ioutil"
 	"log"
@@ -70,6 +71,8 @@ func getProcessId() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	// remove any newlines
+	pidData = bytes.TrimRight(pidData, "\n")
 	pid, err := strconv.Atoi(string(pidData))
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Fix parsing pid files that may contain newlines

It's seen that very rarely the pid file might be created with a newline
and then that would cause the process to restart continuously since we
fail to parse the pid into an integer. Fix by trimming of newlines.

Signed-off-by: Noel Georgi <git@frezbo.dev>