### PR TITLE
chore: update extension spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Any paths in the `rootfs` should be contained within the following hierarchies:
 
 - `/etc/cri/conf.d/`
 - `/lib/firmware/`
+- `/lib64/ld-linux-x86-64.so.2`
 - `/usr/etc/udev/rules.d`
 - `/usr/local/`
 


### PR DESCRIPTION
Update extension spec to support glibc standard path.

When needing to run NVIDIA workloads which require tools build around
glibc compiled to a prefix like `/usr/local/glibc`, apps compiled against
glibc had to be invoked as `/usr/local/glibc/lib/ld-linux-x86-64.so.2 <full path to
app>`. Allowing `/lib64/ld-linux-x86-64.so.2` as a allowlist in
extension spec would allow to create a symlink in
`/lib64/ld-linux-x86-64.so.2` which points to
`/usr/local/glibc/lib/ld-linux-x86-64.so.2`.

Signed-off-by: Noel Georgi <git@frezbo.dev>