### PR TITLE
fix: nvidia pkg versioning

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.2.0-alpha.0-25-g6feece4
+  PKGS_VERSION: v1.2.0-4-ga7609bb
   LINUX_FIRMWARE_VERSION: "20220411" # update this when updating PKGS_VERSION above
 
 labels:

--- a/nvidia-gpu/nvidia-modules/pkg.yaml
+++ b/nvidia-gpu/nvidia-modules/pkg.yaml
@@ -5,7 +5,7 @@ dependencies:
  - stage: base
 # The pkgs version for a particular release of Talos as defined in
 # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
- - image: "{{ .PKGS_PREFIX }}/nvidia-open-gpu-kernel-modules:v1.2.0"
+ - image: "{{ .PKGS_PREFIX }}/nvidia-open-gpu-kernel-modules-pkg:{{ .PKGS_VERSION }}"
 steps:
   - prepare:
       - |

--- a/nvidia-gpu/nvidia-modules/vars.yaml
+++ b/nvidia-gpu/nvidia-modules/vars.yaml
@@ -1,2 +1,2 @@
 # the first part is the driver version and the second the talos version for which the module is built against
-VERSION: "{{ .NVIDIA_DRIVER_VERSION_MAJOR }}.{{ .NVIDIA_DRIVER_VERSION_MINOR }}-v1.2.0-beta.0"
+VERSION: "{{ .NVIDIA_DRIVER_VERSION_MAJOR }}.{{ .NVIDIA_DRIVER_VERSION_MINOR }}-{{ .BUILD_ARG_TAG }}"


### PR DESCRIPTION
We'd have to now tag `extensions` with the same version as Talos for
every Talos release.

Signed-off-by: Noel Georgi <git@frezbo.dev>