### PR TITLE
release(v1.2.0-beta.2): prepare release

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.2.0-4-ga7609bb
+  PKGS_VERSION: v1.2.0-7-gb115be6
   LINUX_FIRMWARE_VERSION: "20220411" # update this when updating PKGS_VERSION above
 
 labels:


### PR DESCRIPTION
Bump `pkgs` to the version used in [v1.2.0-beta.2](https://github.com/siderolabs/talos/blob/v1.2.0-beta.2/pkg/machinery/gendata/data/pkgs) of Talos.

Signed-off-by: Noel Georgi <git@frezbo.dev>