### PR TITLE
feat: update releases

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.3.0-alpha.0-25-g0ac7773
+  PKGS_VERSION: v1.3.0-alpha.0-29-g91e73b3
   LINUX_FIRMWARE_VERSION: "20220913" # update this when updating PKGS_VERSION above
 
 labels:

--- a/container-runtime/gvisor/pkg.yaml
+++ b/container-runtime/gvisor/pkg.yaml
@@ -6,10 +6,10 @@ dependencies:
 steps:
   - sources:
       # gvisor repo 'master' branch is Bazel-bazed, so we need to find matching commit in the "go" branch
-      - url: https://github.com/google/gvisor/archive/4e7fd140e8d0056f8f031950fcace8ff4d48a526.tar.gz
+      - url: https://github.com/google/gvisor/archive/c8eb96ca70711941800df0d7b6b8e727195ca393.tar.gz
         destination: gvisor.tar.gz
-        sha256: c4171ef3c274126f9e7594a7f3cd37ec5f96aa8e1dfc64e5e46fc40b8bd60545
-        sha512: 3fc729724eaec5595706596557385675d8039e537c40876fd6d9ea4bd81b382ad688aa90dea6bbe0a1833946353887280c8047787838e5bb242d18c86282aa4f
+        sha256: 6d90dd933a60d41772ecc5aa8ff7f9115a7bfa22c79d5ac48187b6db6acf777d
+        sha512: 5225e1bde7f1f62d9cf9d090ccce46dd284b40f36b6ebef96adf93a28cc8b2f5dec8dffa09f1c3f570042fb7df6c38918f0f8fad53b13f28e608a430d05235c9
     env:
       GOPATH: /go
     prepare:

--- a/container-runtime/vars.yaml
+++ b/container-runtime/vars.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-tags extractVersion=^release-(?<version>.*)$ versioning=loose depName=google/gvisor
-GVISOR_VERSION: 20220919.0
+GVISOR_VERSION: 20221010.0

--- a/examples/hello-world-service/src/go.mod
+++ b/examples/hello-world-service/src/go.mod
@@ -1,3 +1,3 @@
 module github.com/siderolabs/hello-world
 
-go 1.17
+go 1.19

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
@@ -2,4 +2,4 @@ module nvidia-persistenced-wrapper
 
 go 1.19
 
-require golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8
+require golang.org/x/sys v0.0.0-20221010170243-090e33056c14

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/storage/iscsi-tools/iscsid-wrapper/go.mod
+++ b/storage/iscsi-tools/iscsid-wrapper/go.mod
@@ -2,4 +2,4 @@ module iscsid-wrapper
 
 go 1.19
 
-require golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8
+require golang.org/x/sys v0.0.0-20221010170243-090e33056c14

--- a/storage/iscsi-tools/iscsid-wrapper/go.sum
+++ b/storage/iscsi-tools/iscsid-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/storage/iscsi-tools/open-iscsi/pkg.yaml
+++ b/storage/iscsi-tools/open-iscsi/pkg.yaml
@@ -12,8 +12,8 @@ steps:
   - sources:
       - url: https://github.com/open-iscsi/open-iscsi/archive/refs/tags/{{ .OPEN_ISCSI_VERSION }}.tar.gz
         destination: open-iscsi.tar.gz
-        sha256: d96761e47a69f8214c5fbd251d844f37961b14c3e437b63a15cc64f5b8cba2f0
-        sha512: 619c57b988c6972da09428b3a84ca375ca46653fbfca9cb61389c70a95871b665f93b75b8e6ff2aa993bdb89e2a078a188c0a7b45c3bf9c15a16b496e9ebc892
+        sha256: 9565bdf6b68b223e1e0d455d9a04d7536724a3f5b5a254e9398d06b2a0c6b6d2
+        sha512: 168ce68dc495cc8b2f217ad0373851d681f9274036b8ec562ece513de493adfdbba55f2038518f246f5244f6405102b2e096a9cce15e73fce9654f06790002c1
     prepare:
       - |
         mkdir -p /usr/bin \

--- a/storage/iscsi-tools/vars.yaml
+++ b/storage/iscsi-tools/vars.yaml
@@ -1,5 +1,5 @@
 VERSION: v0.1.2
 # renovate: datasource=github-tags depName=open-iscsi/open-iscsi
-OPEN_ISCSI_VERSION: 2.1.7
+OPEN_ISCSI_VERSION: 2.1.8
 # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=open-iscsi/open-isns
 OPEN_ISNS_VERSION: 0.102


### PR DESCRIPTION
* minor Go bumps
* gvisor: 20221010.0
* open-iscsi: 2.1.8

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>