### PR TITLE
chore: bump dependencies

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,8 +4,8 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.3.0-alpha.0-35-g66c77e9
-  LINUX_FIRMWARE_VERSION: "20221012" # update this when updating PKGS_VERSION above
+  PKGS_VERSION: v1.3.0-alpha.0-39-g1e8df44
+  LINUX_FIRMWARE_VERSION: "20221109" # update this when updating PKGS_VERSION above
   DRBD_DRIVER_VERSION: 9.2.0 # update this when updating PKGS_VERSION above
 
 labels:

--- a/container-runtime/gvisor/pkg.yaml
+++ b/container-runtime/gvisor/pkg.yaml
@@ -6,10 +6,10 @@ dependencies:
 steps:
   - sources:
       # gvisor repo 'master' branch is Bazel-bazed, so we need to find matching commit in the "go" branch
-      - url: https://github.com/google/gvisor/archive/c8eb96ca70711941800df0d7b6b8e727195ca393.tar.gz
+      - url: https://github.com/google/gvisor/archive/4793b32eb08bd852a92e5318d4fb7874a9ba0a78.tar.gz
         destination: gvisor.tar.gz
-        sha256: 6d90dd933a60d41772ecc5aa8ff7f9115a7bfa22c79d5ac48187b6db6acf777d
-        sha512: 5225e1bde7f1f62d9cf9d090ccce46dd284b40f36b6ebef96adf93a28cc8b2f5dec8dffa09f1c3f570042fb7df6c38918f0f8fad53b13f28e608a430d05235c9
+        sha256: 33ef486f8cfb7810dbd99ab7b12b19f24f47f1478d164c898a202915a943a9b6
+        sha512: cddb1afd12064ec6075b6d5cd7154ab6d7ed60d93609eded8a88ce7fd39db03ce13bb187a499928411239df1a8d28a585139e66549ab39fcbc1bf0b8dd31ed28
     env:
       GOPATH: /go
     prepare:

--- a/container-runtime/vars.yaml
+++ b/container-runtime/vars.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-tags extractVersion=^release-(?<version>.*)$ versioning=loose depName=google/gvisor
-GVISOR_VERSION: 20221010.0
+GVISOR_VERSION: 20221107.0

--- a/firmware/intel-ucode/pkg.yaml
+++ b/firmware/intel-ucode/pkg.yaml
@@ -7,8 +7,8 @@ steps:
   - sources:
       - url: https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/refs/tags/microcode-{{ .INTEL_UCODE_VERSION }}.tar.gz
         destination: intel-ucode.tar.gz
-        sha256: 084463c82fbcb679e7fa211e676fd12a8ae464fed7d445e92ccc67101ced5a94
-        sha512: 1c91df1cbba33953f4ad19cc53215cad843c61a08509596fad32a84b4f0012d9d29bce64b58eb405c345af7f646d5982e45227570ce3605780be6e8bf31a63e1
+        sha256: 8d14a914815f56c27b1f41be0fd699d1afcfdbc05432056427e455100798975e
+        sha512: d86bee1269d31d3028f0d2b7d4886795b96d8f1f9d5dbd5149c2dd4cec3b0319fd869f8138f283e2135ecb0bb6387cfd3c2ef1f597b4194a250ac4f2df7f15a4
     prepare:
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml

--- a/firmware/vars.yaml
+++ b/firmware/vars.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-releases extractVersion=^microcode-(?<version>.*)$ versioning=loose depName=intel/Intel-Linux-Processor-Microcode-Data-Files
-INTEL_UCODE_VERSION: 20220809
+INTEL_UCODE_VERSION: 20221108

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
@@ -2,4 +2,4 @@ module nvidia-persistenced-wrapper
 
 go 1.19
 
-require golang.org/x/sys v0.0.0-20221010170243-090e33056c14
+require golang.org/x/sys v0.2.0

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
-golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/storage/iscsi-tools/iscsid-wrapper/go.mod
+++ b/storage/iscsi-tools/iscsid-wrapper/go.mod
@@ -2,4 +2,4 @@ module iscsid-wrapper
 
 go 1.19
 
-require golang.org/x/sys v0.0.0-20221010170243-090e33056c14
+require golang.org/x/sys v0.2.0

--- a/storage/iscsi-tools/iscsid-wrapper/go.sum
+++ b/storage/iscsi-tools/iscsid-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
-golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/storage/iscsi-tools/open-iscsi/pkg.yaml
+++ b/storage/iscsi-tools/open-iscsi/pkg.yaml
@@ -40,7 +40,7 @@ steps:
         export PKG_CONFIG_PATH=/usr/lib/pkgconfig
 
         LDFLAGS="$LDFLAGS -L/usr/local/lib" \
-        make -j $(nproc) \
+        make \
           prefix=/usr/local \
           exec_prefix=/usr/local \
           localstatedir=/var \


### PR DESCRIPTION
* gvisor: 20221107.0
* Linux firmware: 20221109
* Intel ucode: 20221108

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>