### PR TITLE
fix: iscsi-tools extension

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -16,6 +16,12 @@ See [Talos Linux documentation](https://www.talos.dev/v1.2/talos-guides/configur
 
 [notes]
 
+    [notes.iscsi-tools]
+        title = "fixed iscsci tools extension"
+        description = """\
+iscsi-tools extension version v0.1.2 is broken, please use v0.1.3 or higher.
+"""
+
     [notes.tpu]
         title = "Coral.ai TPU gasket driver"
         description = """\

--- a/storage/iscsi-tools/open-iscsi/pkg.yaml
+++ b/storage/iscsi-tools/open-iscsi/pkg.yaml
@@ -57,6 +57,7 @@ steps:
         rm -rf /rootfs/usr/local/include
         rm -rf /rootfs/usr/local/lib/pkgconfig
         rm -rf /rootfs/usr/local/etc/iscsi/ifaces
+        rm -rf /rootfs/etc
 
         cp /pkg/files/passwd /rootfs/usr/local/etc/passwd
 finalize:

--- a/storage/iscsi-tools/vars.yaml
+++ b/storage/iscsi-tools/vars.yaml
@@ -1,4 +1,4 @@
-VERSION: v0.1.2
+VERSION: v0.1.3
 # renovate: datasource=github-tags depName=open-iscsi/open-iscsi
 OPEN_ISCSI_VERSION: 2.1.8
 # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=open-iscsi/open-isns


### PR DESCRIPTION
Fix iscsi-tools extension by removed files under `/etc` in rootfs.

Fixes: #92

Signed-off-by: Noel Georgi <git@frezbo.dev>