### PR TITLE
feat: update releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ space = $(empty) $(empty)
 TARGETS = \
 		amd-ucode \
 		bnx2-bnx2x \
-		drbd \
 		gasket-driver \
 		gvisor \
 		hello-world-service \
@@ -48,6 +47,9 @@ TARGETS = \
 		nvidia-container-toolkit \
 		nvidia-fabricmanager \
 		nvidia-open-gpu-kernel-modules
+
+# Temporarily disabled, as drbd-pkg fails to build with Linux 6.1
+#		drbd \
 
 NONFREE_TARGETS =
 

--- a/Pkgfile
+++ b/Pkgfile
@@ -4,8 +4,8 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.3.0
-  LINUX_FIRMWARE_VERSION: "20221109" # update this when updating PKGS_VERSION above
+  PKGS_VERSION: v1.4.0-alpha.0-6-g325c9bf
+  LINUX_FIRMWARE_VERSION: "20221214" # update this when updating PKGS_VERSION above
   DRBD_DRIVER_VERSION: 9.2.0 # update this when updating PKGS_VERSION above
 
 labels:

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ All system extensions provided by Sidero Labs can be found in the [ghcr.io regis
 | [bnx2-bnx2x](firmware/bnx2-bnx2x/)   | [ghcr.io/siderolabs/bnx2-bnx2x](https://github.com/siderolabs/extensions/pkgs/container/bnx2-bnx2x)   | Broadcom NetXtreme firmware | `linux firmware version` |
 | [intel-ucode](firmware/intel-ucode/) | [ghcr.io/siderolabs/intel-ucode](https://github.com/siderolabs/extensions/pkgs/container/intel-ucode) | Intel CPU microcode updates | `upstream version`       |
 
-
 ### Drivers
+
 | Name                                 | Image                                                                                                                                       | Description                          | Version Format                                        |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------- |
 | [gasket](drivers/gasket/)            | [ghcr.io/siderolabs/gasket-driver](https://github.com/siderolabs/extensions/pkgs/container/gasket-driver)                                   | Driver for Google Coral PCIe devices | `gasket driver upstream short commit`-`talos version` |
@@ -40,7 +40,7 @@ All system extensions provided by Sidero Labs can be found in the [ghcr.io regis
 | Name                                | Image                                                                                                 | Description      | Version Format |
 | ----------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------- | -------------- |
 | [iscsi-tools](storage/iscsi-tools/) | [ghcr.io/siderolabs/iscsi-tools](https://github.com/siderolabs/extensions/pkgs/container/iscsi-tools) | Open iSCSI tools | `v0.1.0`       |
-| [drbd](storage/drbd/) | [ghcr.io/siderolabs/drbd](https://github.com/siderolabs/extensions/pkgs/container/drbd) | DRBD driver module | `v0.1.0`       |
+| [drbd](storage/drbd/) *disabled*    | [ghcr.io/siderolabs/drbd](https://github.com/siderolabs/extensions/pkgs/container/drbd) | DRBD driver module | `v0.1.0`       |
 
 ### Power
 

--- a/container-runtime/gvisor/pkg.yaml
+++ b/container-runtime/gvisor/pkg.yaml
@@ -6,10 +6,10 @@ dependencies:
 steps:
   - sources:
       # gvisor repo 'master' branch is Bazel-bazed, so we need to find matching commit in the "go" branch
-      - url: https://github.com/google/gvisor/archive/4793b32eb08bd852a92e5318d4fb7874a9ba0a78.tar.gz
+      - url: https://github.com/google/gvisor/archive/6ec92611f02490966e8a2d482e33f7ba38546b90.tar.gz
         destination: gvisor.tar.gz
-        sha256: 33ef486f8cfb7810dbd99ab7b12b19f24f47f1478d164c898a202915a943a9b6
-        sha512: cddb1afd12064ec6075b6d5cd7154ab6d7ed60d93609eded8a88ce7fd39db03ce13bb187a499928411239df1a8d28a585139e66549ab39fcbc1bf0b8dd31ed28
+        sha256: 529885afba906aa277fdba90254c5ec42d4f8757904b1ee1a134f9f48cf1909c
+        sha512: d3e6be510c76d4747daabfe447117526072ab7eb6e7ad9a793246b32459a64639380eb023e6111c5810c6e6d67a33418f48109619ba865e6cd61994259040415
     env:
       GOPATH: /go
     prepare:

--- a/container-runtime/vars.yaml
+++ b/container-runtime/vars.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-tags extractVersion=^release-(?<version>.*)$ versioning=loose depName=google/gvisor
-GVISOR_VERSION: 20221107.0
+GVISOR_VERSION: 20221212.0

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
@@ -2,4 +2,4 @@ module nvidia-persistenced-wrapper
 
 go 1.19
 
-require golang.org/x/sys v0.2.0
+require golang.org/x/sys v0.3.0

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
-golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/pkg.yaml
@@ -11,13 +11,13 @@ steps:
     # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
       - url: https://download.nvidia.com/XFree86/Linux-aarch64/{{ .NVIDIA_DRIVER_VERSION }}/NVIDIA-Linux-aarch64-{{ .NVIDIA_DRIVER_VERSION }}.run
         destination: nvidia.run
-        sha256: 0d2ac6c6ca144c8c7bbf1a62034998463b21f2660a793607d88c031650d93e93
-        sha512: 31ec7ba727bf14263eeadc3880bd8f2aaa0fe8c144aa216bb8af06a154dd1aa5f4a787fe386b20f5d739a49c80435bca5f6deba3010c593e1e54ecd29b4ab1b0
+        sha256: 3f6b4ff740dfea17fbb80ff0cb8b83500b16323b64fa7d19b830bdc6b89d66eb
+        sha512: 1a5ca9fbf25ce26a59f295815491cef56df91c72ab775d7453e46af7ce123af6bdeae87085aa199717036b2c7bc4406df4da4d6238ca51d08b382fb3792bcc45
     # {{ else }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
       - url: https://download.nvidia.com/XFree86/Linux-x86_64/{{ .NVIDIA_DRIVER_VERSION }}/NVIDIA-Linux-x86_64-{{ .NVIDIA_DRIVER_VERSION }}.run
         destination: nvidia.run
-        sha256: 0492ddc5b5e65aa00cbc762e8d6680205c8d08e103b7131087a15126aee495e9
-        sha512: 5221a4ac071eb39a37a841f19cfe4983286dc35e918956b40604404ef36c122612475df7b9a391a9a70bd60f44e598c8a0e5ec54ccc3e90d51f01e1b2fbe5e33
+        sha256: dce1c184f9f038be72237ccd29c66bb151077f6037f1c158c83d582bd2dba8ca
+        sha512: 9895c8001b90b6367dbead1b34a86d49fa91171adcc72498fe537dc2e5959ef344e25b00091b662ba57bf751003ccff967e33262a3f64147ff0a253ecf582e46
     # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
     prepare:
       - |

--- a/nvidia-gpu/nvidia-fabricmanager/pkg.yaml
+++ b/nvidia-gpu/nvidia-fabricmanager/pkg.yaml
@@ -8,13 +8,13 @@ steps:
     # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
       - url: https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-{{ .NVIDIA_FABRICMANAGER_VERSION }}-archive.tar.xz
         destination: fabricmanager.tar.xz
-        sha256: dac775eaed6bf26ffb7b8e281db7fd83f5edca5625dc86a0aca26f479263b38d
-        sha512: 7f2c2415c06b6fc993c80e5b21b3c47f5e344e56c5504c72bdfa41a71cd31886b6feb784c93ba74a526e548df0293b6fce1722b09aba822c32b5a5c7255deae1
+        sha256: 6c74abdb3f5bb54742a71e0c610d9e550c2754a10f12581dc058324799416a44
+        sha512: 97b9928a965ffde294e6299e474455c29f68598c428c0b833b5da76d9754aa4bc039b121e0e6773e77a50c0f88154c8c5d8596f86e6e5db712c47df06169bbe4
     # {{ else }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
       - url: https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-{{ .NVIDIA_FABRICMANAGER_VERSION }}-archive.tar.xz
         destination: fabricmanager.tar.xz
-        sha256: f3271a899151c762641e2beab68335ab1f52cb5beecef0f474780f8fbe804f58
-        sha512: 2beb4de1415d234a76981d03cc9f85fa6ff47bdccf9de679547ff37970d680d6227d1696eefaa8921acd9c9b4df813df9f8ec0b448bbeaf15fb8e507016edb92
+        sha256: 1adfbb12817f213e39d389442505f75dd7cc085ce4afa98ecdc2ea26dcb321da
+        sha512: 8e91c084148a8df3f5d2fd6f3f4b470719da2459618b560b5322433c53274680ff817821dc9aa89e08996c1e917faae5042faaccaa309bd4871561d29edc886a
     # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
     prepare:
       - |

--- a/nvidia-gpu/vars.yaml
+++ b/nvidia-gpu/vars.yaml
@@ -1,6 +1,6 @@
 # renovate: datasource=github-releases depName=NVIDIA/open-gpu-kernel-modules
-NVIDIA_DRIVER_VERSION: 515.65.01
-NVIDIA_FABRICMANAGER_VERSION: 515.65.01
+NVIDIA_DRIVER_VERSION: 525.60.13
+NVIDIA_FABRICMANAGER_VERSION: 525.60.13
 # renovate: datasource=git-tags depName=https://gitlab.com/nvidia/container-toolkit/container-toolkit.git
 CONTAINER_TOOLKIT_VERSION: v1.11.0
 CONTAINER_TOOLKIT_REF: d9de4a09b8fd51a46207398199ecfeb3998ad49d

--- a/storage/iscsi-tools/iscsid-wrapper/go.mod
+++ b/storage/iscsi-tools/iscsid-wrapper/go.mod
@@ -2,4 +2,4 @@ module iscsid-wrapper
 
 go 1.19
 
-require golang.org/x/sys v0.2.0
+require golang.org/x/sys v0.3.0

--- a/storage/iscsi-tools/iscsid-wrapper/go.sum
+++ b/storage/iscsi-tools/iscsid-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
-golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
gvisor: 20221212.0
Linux firmware: 20221214
NVIDIA: 525.60.13

DRBD disabled, as it doesn't build with Linux 6.1.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>