### PR TITLE
chore: use default symlinks from base

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.4.0-alpha.0-6-g325c9bf
+  PKGS_VERSION: v1.4.0-alpha.0-7-g8965bee
   LINUX_FIRMWARE_VERSION: "20221214" # update this when updating PKGS_VERSION above
   DRBD_DRIVER_VERSION: 9.2.0 # update this when updating PKGS_VERSION above
 

--- a/power/nut-client/pkg.yaml
+++ b/power/nut-client/pkg.yaml
@@ -23,10 +23,6 @@ steps:
         mkdir -p /usr/bin \
             && ln -sf /toolchain/bin/env /usr/bin/env
 
-        # Create symlinks for binaries required by libtoolize.
-        ln -s /toolchain/bin/sed /bin/sed
-        ln -s /toolchain/bin/grep /bin/grep
-
         # Create symlinks for files used when building.
         ln -s /toolchain/bin/pkg-config /usr/bin/pkg-config
         ln -s /toolchain/bin/file /usr/bin/file

--- a/storage/iscsi-tools/open-iscsi/pkg.yaml
+++ b/storage/iscsi-tools/open-iscsi/pkg.yaml
@@ -23,9 +23,7 @@ steps:
         tar -xzf open-iscsi.tar.gz --strip-components=1
 
         # Create symlinks for binaries required by libtoolize.
-        ln -s /toolchain/bin/sed /bin/sed
         ln -s /toolchain/bin/sed /usr/bin/sed
-        ln -s /toolchain/bin/grep /bin/grep
 
         # Create symlinks for files used when building.
         ln -s /toolchain/bin/pkg-config /usr/bin/pkg-config


### PR DESCRIPTION
Use default symlinks from [base](https://github.com/siderolabs/pkgs/pull/647).

Signed-off-by: Noel Georgi <git@frezbo.dev>