### PR TITLE
chore: disable provenance in buildx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ PLATFORM ?= linux/amd64,linux/arm64
 PROGRESS ?= auto
 PUSH ?= false
 COMMON_ARGS := --file=Pkgfile
+COMMON_ARGS += --provenance=false
 COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
 COMMON_ARGS += --build-arg=http_proxy=$(http_proxy)


### PR DESCRIPTION
The builds fail to push the image to ghcr.io, because of the new default provenance attestation with buildkit 0.11.0/buildx 0.10.0, so disabling it for now.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>