### PR TITLE
feat: add mellanox ofed drivers extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ TARGETS = \
 
 # Temporarily disabled, as drbd-pkg fails to build with Linux 6.1
 #		drbd \
+#       mellanox-ofed \
 
 NONFREE_TARGETS =
 

--- a/drivers/mellanox-ofed/manifest.yaml
+++ b/drivers/mellanox-ofed/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: mellanox-ofed
+  version: "$VERSION"
+  author: SideroLabs
+  description: |
+    This system extension provides kernel module driver for Mellanox OFED built against a specific Talos version.
+  compatibility:
+    talos:
+      version: ">= v1.3.0"

--- a/drivers/mellanox-ofed/pkg.yaml
+++ b/drivers/mellanox-ofed/pkg.yaml
@@ -1,0 +1,22 @@
+name: mellanox-ofed
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+ - stage: base
+ # The pkgs version for a particular release of Talos as defined in
+ # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
+ - image: "{{ .PKGS_PREFIX }}/mellanox-ofed-pkg:{{ .PKGS_VERSION }}"
+steps:
+  - prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+  - install:
+      - |
+        mkdir -p /rootfs/lib/modules
+
+        cp -R /lib/modules/* /rootfs/lib/modules
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/drivers/mellanox-ofed/vars.yaml
+++ b/drivers/mellanox-ofed/vars.yaml
@@ -1,0 +1,2 @@
+# the first part is the driver version and the second the talos version for which the module is built against
+VERSION: "5.8-1.1.2.1-{{ .BUILD_ARG_TAG }}"


### PR DESCRIPTION
Add Mellanox OFED drivers extension.
Keeping it disabled until it builds with kernel 6.1 Ref: https://github.com/siderolabs/pkgs/pull/661

Signed-off-by: Noel Georgi <git@frezbo.dev>