### PR TITLE
fix: renovate regex

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,7 +41,8 @@
         {
             "matchPackageNames": [
                 "golang/go",
-                "nvidia/open-gpu-kernel-modules"
+                "nvidia/open-gpu-kernel-modules",
+                "open-iscsi/open-isns"
             ],
             "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d+)?$"
         },
@@ -49,7 +50,7 @@
             "matchPackageNames": [
                 "https://sourceware.org/git/glibc.git"
             ],
-            "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>(?!9000$)\\d+)?$"
+            "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>[0-9]{1,3})?$"
         },
         {
             "matchPackagePatterns": [


### PR DESCRIPTION
Renovate regex doesn't support negative lookaheads. For glibc the tag suffix to always ignore is `9000`, so just match versions that have patch versions matching upto `999`.