### PR TITLE
chore: make `PKGS_VERSION` a variable

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -4,9 +4,8 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  PKGS_VERSION: v1.4.0-alpha.0-27-g7493721
-  LINUX_FIRMWARE_VERSION: "20230210" # update this when updating PKGS_VERSION above
-  DRBD_DRIVER_VERSION: 9.2.2 # update this when updating PKGS_VERSION above
+  LINUX_FIRMWARE_VERSION: "20230210" # update this when updating PKGS_VERSION in Makefile
+  DRBD_DRIVER_VERSION: 9.2.2 # update this when updating PKGS_VERSION in Makefile
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/extensions

--- a/drivers/gasket/pkg.yaml
+++ b/drivers/gasket/pkg.yaml
@@ -5,7 +5,7 @@ dependencies:
   - stage: base
   # The pkgs version for a particular release of Talos as defined in
   # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
-  - image: "{{ .PKGS_PREFIX }}/gasket-driver-pkg:{{ .PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/gasket-driver-pkg:{{ .BUILD_ARG_PKGS_VERSION }}"
 steps:
   - prepare:
       - |

--- a/drivers/mellanox-ofed/pkg.yaml
+++ b/drivers/mellanox-ofed/pkg.yaml
@@ -5,7 +5,7 @@ dependencies:
  - stage: base
  # The pkgs version for a particular release of Talos as defined in
  # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
- - image: "{{ .PKGS_PREFIX }}/mellanox-ofed-pkg:{{ .PKGS_VERSION }}"
+ - image: "{{ .PKGS_PREFIX }}/mellanox-ofed-pkg:{{ .BUILD_ARG_PKGS_VERSION }}"
 steps:
   - prepare:
       - |

--- a/firmware/amd-ucode/pkg.yaml
+++ b/firmware/amd-ucode/pkg.yaml
@@ -3,7 +3,7 @@ variant: scratch
 shell: /toolchain/bin/bash
 dependencies:
   - stage: base
-  - image: "{{ .PKGS_PREFIX }}/linux-firmware:{{ .PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/linux-firmware:{{ .BUILD_ARG_PKGS_VERSION }}"
 steps:
   - prepare:
       - |

--- a/firmware/bnx2-bnx2x/pkg.yaml
+++ b/firmware/bnx2-bnx2x/pkg.yaml
@@ -3,7 +3,7 @@ variant: scratch
 shell: /toolchain/bin/bash
 dependencies:
   - stage: base
-  - image: "{{ .PKGS_PREFIX }}/linux-firmware:{{ .PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/linux-firmware:{{ .BUILD_ARG_PKGS_VERSION }}"
 steps:
   - prepare:
       - |

--- a/firmware/i915-ucode/pkg.yaml
+++ b/firmware/i915-ucode/pkg.yaml
@@ -3,7 +3,7 @@ variant: scratch
 shell: /toolchain/bin/bash
 dependencies:
   - stage: base
-  - image: "{{ .PKGS_PREFIX }}/linux-firmware:{{ .PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/linux-firmware:{{ .BUILD_ARG_PKGS_VERSION }}"
 steps:
   - prepare:
       - |

--- a/internal/base/pkg.yaml
+++ b/internal/base/pkg.yaml
@@ -2,8 +2,8 @@ name: base
 variant: scratch
 shell: /toolchain/bin/bash
 dependencies:
-  - image: "{{ .PKGS_PREFIX }}/base:{{ .PKGS_VERSION }}"
-  - image: "{{ .PKGS_PREFIX }}/ca-certificates:{{ .PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/base:{{ .BUILD_ARG_PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/ca-certificates:{{ .BUILD_ARG_PKGS_VERSION }}"
 finalize:
   - from: /
     to: /

--- a/nvidia-gpu/nvidia-modules/pkg.yaml
+++ b/nvidia-gpu/nvidia-modules/pkg.yaml
@@ -5,7 +5,7 @@ dependencies:
  - stage: base
 # The pkgs version for a particular release of Talos as defined in
 # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
- - image: "{{ .PKGS_PREFIX }}/nvidia-open-gpu-kernel-modules-pkg:{{ .PKGS_VERSION }}"
+ - image: "{{ .PKGS_PREFIX }}/nvidia-open-gpu-kernel-modules-pkg:{{ .BUILD_ARG_PKGS_VERSION }}"
 steps:
   - prepare:
       - |

--- a/power/nut-client/pkg.yaml
+++ b/power/nut-client/pkg.yaml
@@ -3,8 +3,8 @@ variant: scratch
 shell: /toolchain/bin/bash
 dependencies:
   - stage: base
-  - image: "{{ .PKGS_PREFIX }}/openssl:{{ .PKGS_VERSION }}"
-  - image: "{{ .PKGS_PREFIX }}/util-linux:{{ .PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/openssl:{{ .BUILD_ARG_PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/util-linux:{{ .BUILD_ARG_PKGS_VERSION }}"
 steps:
   - sources:
       - url: https://github.com/networkupstools/nut/releases/download/v{{ .NUT_VERSION }}/nut-{{ .NUT_VERSION }}.tar.gz

--- a/storage/drbd/pkg.yaml
+++ b/storage/drbd/pkg.yaml
@@ -5,7 +5,7 @@ dependencies:
  - stage: base
 # The pkgs version for a particular release of Talos as defined in
 # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
- - image: "{{ .PKGS_PREFIX }}/drbd-pkg:{{ .PKGS_VERSION }}"
+ - image: "{{ .PKGS_PREFIX }}/drbd-pkg:{{ .BUILD_ARG_PKGS_VERSION }}"
 steps:
   - prepare:
       - |

--- a/storage/iscsi-tools/open-iscsi/pkg.yaml
+++ b/storage/iscsi-tools/open-iscsi/pkg.yaml
@@ -3,9 +3,9 @@ variant: scratch
 shell: /toolchain/bin/bash
 dependencies:
   - stage: base
-  - image: "{{ .PKGS_PREFIX }}/kmod:{{ .PKGS_VERSION }}"
-  - image: "{{ .PKGS_PREFIX }}/openssl:{{ .PKGS_VERSION }}"
-  - image: "{{ .PKGS_PREFIX }}/util-linux:{{ .PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/kmod:{{ .BUILD_ARG_PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/openssl:{{ .BUILD_ARG_PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/util-linux:{{ .BUILD_ARG_PKGS_VERSION }}"
   - stage: open-isns
     from: /rootfs
 steps:

--- a/storage/iscsi-tools/open-isns/pkg.yaml
+++ b/storage/iscsi-tools/open-isns/pkg.yaml
@@ -3,7 +3,7 @@ variant: scratch
 shell: /toolchain/bin/bash
 dependencies:
   - stage: base
-  - image: "{{ .PKGS_PREFIX }}/openssl:{{ .PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/openssl:{{ .BUILD_ARG_PKGS_VERSION }}"
 steps:
   - sources:
       - url: https://github.com/open-iscsi/open-isns/archive/refs/tags/v{{ .OPEN_ISNS_VERSION }}.tar.gz


### PR DESCRIPTION
Make `PKGS_VERSION` a variable to be able to pass from environment.

Also re-enable drbd per https://github.com/siderolabs/pkgs/pull/679