### PR TITLE
chore: re-enable gvisor cgroup support

### DIFF
--- a/container-runtime/gvisor/runsc.toml
+++ b/container-runtime/gvisor/runsc.toml
@@ -1,3 +1,1 @@
 [runsc_config]
-# See https://github.com/siderolabs/extensions/issues/4
-ignore-cgroups = "true"


### PR DESCRIPTION
Gvisor now works on Talos with cgroup support enabled.

Fixes: #4 