### PR TITLE
fix: nvidia modules autoload

### DIFF
--- a/nvidia-gpu/nvidia-modules/files/nvidia.conf
+++ b/nvidia-gpu/nvidia-modules/files/nvidia.conf
@@ -1,0 +1,4 @@
+blacklist nvidia
+blacklist nvidia_uvm
+blacklist nvidia_drm
+blacklist nvidia_modeset

--- a/nvidia-gpu/nvidia-modules/pkg.yaml
+++ b/nvidia-gpu/nvidia-modules/pkg.yaml
@@ -12,7 +12,10 @@ steps:
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
   - install:
       - |
-        mkdir -p /rootfs/lib/modules
+        mkdir -p /rootfs/lib/modules \
+          /rootfs/usr/local/lib/modprobe.d
+
+        cp /pkg/files/nvidia.conf /rootfs/usr/local/lib/modprobe.d/nvidia.conf
 
         cp -R /lib/modules/* /rootfs/lib/modules
 finalize:


### PR DESCRIPTION
Fixes: https://github.com/siderolabs/talos/issues/7008

Prevent autloading of nvidia modules by default. This allows setting any extra kernel modules args from talos machineconfig.