### PR TITLE
feat: add xen-guest-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ TARGETS = \
 		nut-client \
 		nvidia-container-toolkit \
 		nvidia-fabricmanager \
-		nvidia-open-gpu-kernel-modules
+		nvidia-open-gpu-kernel-modules \
+		xen-guest-agent
 
 # Temporarily disabled, as mellanox-ofed fails to build with Linux 6.1
 #		mellanox-ofed \

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ All system extensions provided by Sidero Labs can be found in the [ghcr.io regis
 | [nvidia-fabricmanager](nvidia-gpu/nvidia-fabricmanager/)         | [NVIDIA fabric manager](https://docs.nvidia.com/datacenter/tesla/pdf/fabric-manager-user-guide.pdf) support for GPU workloads      | `driver version`                   |
 | [nvidia-open-gpu-kernel-modules](nvidia-gpu/nvidia-modules/)     | NVIDIA driver kernel modules                                                                                                       | `driver version`-`talos version`   |
 
+### Virtualization
+
+| Name                                               | Image                                                                                                         | Description                                                       | Version Format                     |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------- |
+| [xen-guest-agent](virtualization/xen-guest-agent/) | [ghcr.io/siderolabs/xen-guest-agent](https://github.com/siderolabs/extensions/pkgs/container/xen-guest-agent) | [xen-guest-agent](https://gitlab.com/xen-project/xen-guest-agent) | `upstream version`-`talos version` |
+
 ## Building Extensions
 
 In the current form, building extensions requires the use of our [bldr](https://github.com/siderolabs/bldr) tool.

--- a/virtualization/xen-guest-agent/manifest.yaml
+++ b/virtualization/xen-guest-agent/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: xen-guest-agent
+  version: "$VERSION"
+  author: Cas de Reuver
+  description: |
+    This system extension provides xen-guest-agent for machines running on XenServer/XCP-ng.
+  compatibility:
+    talos:
+      version: ">= v1.2.0"

--- a/virtualization/xen-guest-agent/pkg.yaml
+++ b/virtualization/xen-guest-agent/pkg.yaml
@@ -1,0 +1,25 @@
+name: xen-guest-agent
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - sources:
+      - url: https://gitlab.com/api/v4/projects/44965029/jobs/artifacts/cdr%2Fbuild-container/download?job=build-linux-default
+        destination: xen-guest-agent.tar.gz
+    prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+        tar xzf /pkg/xen-guest-agent.tar.gz
+    install:
+      - |
+        chmod +x /pkg/target/debug/xen-guest-agent
+        mkdir -p /rootfs/usr/local/lib/containers/xen-guest-agent
+        cp /pkg/target/debug/xen-guest-agent /rootfs/usr/local/lib/containers/xen-guest-agent/usr/sbin/xen-guest-agent
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /
+  - from: /pkg/xen-guest-agent.yaml
+    to: /rootfs/usr/local/etc/containers/

--- a/virtualization/xen-guest-agent/vars.yaml
+++ b/virtualization/xen-guest-agent/vars.yaml
@@ -1,0 +1,1 @@
+VERSION: "{{ .BUILD_ARG_TAG }}"

--- a/virtualization/xen-guest-agent/xen-guest-agent.yaml
+++ b/virtualization/xen-guest-agent/xen-guest-agent.yaml
@@ -1,0 +1,18 @@
+name: xen-guest-agent
+container:
+  entrypoint: /usr/sbin/xen-guest-agent
+  mounts:
+    - source: /lib/modules
+      destination: /lib/modules
+      type: bind
+      options:
+        - bind
+        - rw
+  security:
+    writeableRootfs: true
+    writeableSysfs: true
+depends:
+  - network:
+    - addresses
+    - etcfiles
+restart: always


### PR DESCRIPTION
This adds the xen-guest-agent system extension which provides metrics and signal controls to Xenserver/XCP-ng