### PR TITLE
feat: added a new extension that installs the required drivers to operate usb modems under Talos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ TARGETS = \
 		nut-client \
 		nvidia-container-toolkit \
 		nvidia-fabricmanager \
-		nvidia-open-gpu-kernel-modules
+		nvidia-open-gpu-kernel-modules \
+		usb-modem-drivers
 
 # Temporarily disabled, as mellanox-ofed fails to build with Linux 6.1
 #		mellanox-ofed \

--- a/drivers/usb-modem/README.md
+++ b/drivers/usb-modem/README.md
@@ -65,3 +65,34 @@ or
  kern:    info: [2023-06-07T16:40:10.265654521Z]: usb 6-1.2: GSM modem (1-port) converter now attached to ttyUSB7    
  kern:    info: [2023-06-07T16:40:10.280291521Z]: qmi_wwan 6-1.2:1.4: cdc-wdm1: USB WDM device  
 ```
+
+## Configurtion
+
+Talos currently does not have an OS level method of dialing up cellular modems, such as `ModemManager` or `uqmi`, so you will
+probably want to ignore it on the system level, pass the modems `/dev/` devices to a pod, and dial it up there using a tool such
+as `ModemManager` or `uqmi`.
+
+first, ignore the interface on the Talos level, so Talos doesn't try to bring it up:
+
+```yaml
+machine:
+  network:
+    interfaces:
+      - interface: wwan1 # The modem interface name, if you have several modems, you can optionally use deviceSelector instead.
+        ignore: true # ignore the interface.
+```
+
+Next, you can create a pod that might contain something like this:
+
+```yaml
+    volumeMounts:
+    - name: dev
+      mountPath: /dev/
+  volumes:
+  - name: dev
+    hostPath:
+      path: /dev/ttyUSB1 # you might want to mount all of the /dev/ttyUSB* and /dev/cdc-wdm* devices
+      type: Directory
+```
+
+Now the modem should be available to you normally on the pod.

--- a/drivers/usb-modem/README.md
+++ b/drivers/usb-modem/README.md
@@ -1,0 +1,67 @@
+# usb-modem-drivers extension
+
+## Installation
+
+Add the extension to your machine config and enable the modules, your modem might not require
+all of them, so feel free to remove the ones that are not needed:
+
+```yaml
+machine:
+  install:
+    extensions:
+      - image: ghcr.io/siderolabs/usb-modem-drivers:<VERSION>
+  kernel:
+    modules:
+      - name: usbserial
+      - name: option
+      - name: cdc_mbim
+      - name: qmi_wwan
+      - name: usb_wwan
+      - name: usbnet
+      - name: ax88796b
+      - name: asix
+      - name: ax88179_178a
+      - name: cdc_ether
+      - name: cdc_ncm
+      - name: net1080
+      - name: cdc_subset
+      - name: belkin_sa
+      - name: zaurus
+      - name: cdc_wdm
+      - name: rtl8153_ecm
+```
+
+## Verifiying
+
+You can verify the modules are enabled by reading the `/proc/modules` where it _should_ show the module is live.
+
+For example:
+
+```
+❯ talosctl -n 192.168.32.5  read /proc/modules
+usbnet 20480 - - Live 0xffffffffc01c9000 (O)
+cdc_wdm 94208 - - Live 0xffffffffc01aa000 (O)
+...
+...
+```
+
+In addition, if your USB module is installed and you have a USB modem connected to the system, you should be able to verify it's presence at `/dev/cdc-wdm1` or see a new network interface at `wwan1`.
+
+For example:
+
+```
+❯ talosctl -n 192.168.32.5  ls -l /dev/cdc-wdm1
+NODE           MODE          UID   GID   SIZE(B)   LASTMOD           NAME
+192.168.32.5   Dcrw-rw----   0     44    0         Sep 10 18:15:52   /dev/cdc-wdm1
+```
+
+or
+
+```
+❯ talosctl -n 192.168.32.5 dmesg
+# look for lines like these:
+ kern:    info: [2023-06-07T16:40:10.189868521Z]: usbcore: registered new interface driver usbhid                                                                                                  
+ kern:    info: [2023-06-07T16:40:10.190066521Z]: option 6-1.2:1.3: GSM modem (1-port) converter detected  
+ kern:    info: [2023-06-07T16:40:10.265654521Z]: usb 6-1.2: GSM modem (1-port) converter now attached to ttyUSB7    
+ kern:    info: [2023-06-07T16:40:10.280291521Z]: qmi_wwan 6-1.2:1.4: cdc-wdm1: USB WDM device  
+```

--- a/drivers/usb-modem/README.md
+++ b/drivers/usb-modem/README.md
@@ -85,6 +85,21 @@ machine:
 Next, you can create a pod that might contain something like this:
 
 ```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ModemManager
+  namespace: modems # you might have to adjust your security settings for this namespace
+spec:
+  hostNetwork: true
+  nodeName: modems-server
+  containers:
+  - name: ubuntu-container
+    image: ubuntu:latest
+    command: ["/bin/bash", "-c", "--"]
+    args: ["while true; do sleep 30; done;"]
+    securityContext:
+      privileged: true
     volumeMounts:
     - name: dev
       mountPath: /dev/

--- a/drivers/usb-modem/manifest.yaml
+++ b/drivers/usb-modem/manifest.yaml
@@ -6,7 +6,7 @@ metadata:
   description: |
     This system extension provides USB modem drivers kernel modules built against a specific Talos version.
     This driver is required for USB modems to function. This extension includes all the drivers needed to
-    operate any USB module under Linux, but your device might not require all of them. Read your device's
+    operate any USB modem under Linux, but your device might not require all of them. Read your device's
     docs to learn which drivers you need, or just enable them all as a starting point.
   compatibility:
     talos:

--- a/drivers/usb-modem/manifest.yaml
+++ b/drivers/usb-modem/manifest.yaml
@@ -1,0 +1,13 @@
+version: v1alpha1
+metadata:
+  name: usb-modem
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides USB modem drivers kernel modules built against a specific Talos version.
+    This driver is required for USB modems to function. This extension includes all the drivers needed to
+    operate any USB module under Linux, but your device might not require all of them. Read your device's
+    docs to learn which drivers you need, or just enable them all as a starting point.
+  compatibility:
+    talos:
+      version: ">= v1.4.5"

--- a/drivers/usb-modem/pkg.yaml
+++ b/drivers/usb-modem/pkg.yaml
@@ -1,0 +1,22 @@
+name: usb-modem-drivers
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  # The pkgs version for a particular release of Talos as defined in
+  # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
+  - image: "{{ .PKGS_PREFIX }}/usb-modem-drivers-pkg:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+  - install:
+      - |
+        mkdir -p /rootfs/lib/modules
+
+        cp -R /lib/modules/* /rootfs/lib/modules
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/drivers/usb-modem/vars.yaml
+++ b/drivers/usb-modem/vars.yaml
@@ -1,0 +1,2 @@
+# update when pkgs version is updated
+VERSION: "97aeba58-{{ .BUILD_ARG_TAG }}"


### PR DESCRIPTION
added a new extension that installs the required drivers to operate usb modems under Talos
requires: https://github.com/siderolabs/pkgs/pull/738