### PR TITLE
Add `qemu-guest-agent` extension.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ TARGETS = \
 		nvidia-container-toolkit \
 		nvidia-fabricmanager \
 		nvidia-open-gpu-kernel-modules \
+		qemu-guest-agent \
 		tailscale \
 		usb-modem-drivers
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ All system extensions provided by Sidero Labs can be found in the [ghcr.io regis
 | ------------------------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------- |
 | [nut-client](power/nut-client/) | [ghcr.io/siderolabs/nut-client](https://github.com/siderolabs/talos-extensions/pkgs/container/nut-client) | [Network UPS Tools](https://networkupstools.org) upsmon client | `upstream version`-`talos version` |
 
+### QEMU
+
+| Name                                       | Image                                                                                                                 | Description                                                   | Version Format     |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------ |
+| [qemu-guest-agent](qemu/qemu-guest-agent/) | [ghcr.io/siderolabs/qemu-guest-agent](https://github.com/siderolabs/talos-extensions/pkgs/container/qemu-guest-agent) | [QEMU Guest Agent](https://wiki.qemu.org/Features/GuestAgent) | `upstream version` |
+
 ### NVIDIA GPU
 
 | Name                                                             | Description                                                                                                                        | Version Format                     |

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -15,6 +15,11 @@ See [Talos Linux documentation](https://www.talos.dev/v1.5/talos-guides/configur
 """
 
 [notes]
+    [notes.qemu-guest-agent]
+        title = "QEMU Guest Agent"
+        description = """\
+QEMU Guest Agent is now supported as Talos System Extension. Requires Talos v1.5.0 or later.
+"""
 
     [notes.tailscale]
         title = "Tailscale"

--- a/qemu/qemu-guest-agent/README.md
+++ b/qemu/qemu-guest-agent/README.md
@@ -1,0 +1,45 @@
+# qemu-guest-agent extension
+
+## Usage
+
+Enable the extension in the machine configuration before installing Talos:
+
+```yaml
+machine:
+  install:
+    extensions:
+      - image: ghcr.io/siderolabs/qemu-guest-agent:<VERSION>
+```
+
+## Testing
+
+Confirm extension service is running
+
+```bash
+$ talosctl service ext-qemu-guest-agent
+NODE     192.168.1.1
+ID       ext-qemu-guest-agent
+STATE    Running
+HEALTH   ?
+EVENTS   [Running]: Started task ext-qemu-guest-agent (PID 1941) for container ext-qemu-guest-agent (4s ago)
+         [Preparing]: Creating service runner (4s ago)
+         [Preparing]: Running pre state (4s ago)
+         [Waiting]: Waiting for service "cri" to be "up" (5s ago)
+         [Waiting]: Waiting for service "containerd" to be "up", service "cri" to be registered, file "/dev/virtio-ports/org.qemu.guest_agent.0" to exist (6s ago)
+         [Waiting]: Waiting for service "containerd" to be registered, service "cri" to be registered, file "/dev/virtio-ports/org.qemu.guest_agent.0" to exist (8s ago)
+         [Waiting]: Waiting for service "containerd" to be "up", service "cri" to be "up", file "/dev/virtio-ports/org.qemu.guest_agent.0" to exist (9s ago)
+```
+
+### Proxmox
+
+In the VM “Options” tab, ensure “QEMU Guest Agent” is set to “Enabled”. If it was not already enabled, you will need to reboot the VM for the `/dev/virtio-ports/org.qemu.guest_agent.0` device to be available.
+
+The “IPs” field in the VM “Summary” tab should now be populated and the “Shutdown” button in the Proxmox UI should start an orderly shutdown, e.g.
+
+```
+192.168.1.1: user: warning: [2023-06-28T16:38:41.270046585Z]: [talos] shutdown via API received. actor id: b72e2882-9e06-4626-8422-bb2a7410f0ea
+192.168.1.1: user: warning: [2023-06-28T16:38:41.287740585Z]: [talos] shutdown sequence: 10 phase(s)
+192.168.1.1: user: warning: [2023-06-28T16:38:41.288028585Z]: [talos] phase drain (1/10): 1 tasks(s)
+192.168.1.1: user: warning: [2023-06-28T16:38:41.288401585Z]: [talos] task cordonAndDrainNode (1/1): starting
+...
+```

--- a/qemu/qemu-guest-agent/glib/pkg.yaml
+++ b/qemu/qemu-guest-agent/glib/pkg.yaml
@@ -1,0 +1,40 @@
+name: glib
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  - image: "{{ .PKGS_PREFIX }}/openssl:{{ .BUILD_ARG_PKGS }}"
+  - stage: pcre2
+steps:
+  - sources:
+      - url: https://download.gnome.org/sources/glib/2.76/glib-{{ .GLIB_VERSION }}.tar.xz
+        destination: glib.tar.xz
+        sha256: c0be444e403d7c3184d1f394f89f0b644710b5e9331b54fa4e8b5037813ad32a
+        sha512: 291b8913918d411b679442b888f56893a857a77decfe428086c8bd1da1949498938ddb0bf254ed99d192e4a09b5e8cee1905fd6932ee642463fb229cac7c226e
+    prepare:
+      - |
+        tar -xf glib.tar.xz --strip-components=1
+        rm glib.tar.xz
+      - |
+        mkdir -p /usr/bin
+
+        ln -s /toolchain/bin/env /usr/bin/env
+        ln -s /toolchain/bin/python3 /toolchain/bin/python
+
+        pip3 install ninja
+    build:
+      - |
+        export PKG_CONFIG_PATH=/usr/lib/pkgconfig
+
+        meson setup \
+          --prefix=/usr \
+          -Ddefault_library=both \
+          _build
+
+        ninja -C _build
+    install:
+      - |
+        DESTDIR=/rootfs ninja -C _build install
+finalize:
+  - from: /rootfs
+    to: /

--- a/qemu/qemu-guest-agent/manifest.yaml
+++ b/qemu/qemu-guest-agent/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: qemu-guest-agent
+  version: "$VERSION"
+  author: Markus Reiter
+  description: |
+    This system extension provides the QEMU Guest Agent service.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"

--- a/qemu/qemu-guest-agent/pcre2/pkg.yaml
+++ b/qemu/qemu-guest-agent/pcre2/pkg.yaml
@@ -1,0 +1,28 @@
+name: pcre2
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - sources:
+      - url: https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{{ .PCRE2_VERSION }}/pcre2-{{ .PCRE2_VERSION }}.tar.bz2
+        destination: pcre2.tar.bz2
+        sha256: 8d36cd8cb6ea2a4c2bb358ff6411b0c788633a2a45dabbf1aeb4b701d1b5e840
+        sha512: 72fbde87fecec3aa4b47225dd919ea1d55e97f2cbcf02aba26e5a0d3b1ffb58c25a80a9ef069eb99f9cf4e41ba9604ad06a7ec159870e1e875d86820e12256d3
+    prepare:
+      - |
+        tar -xf pcre2.tar.bz2 --strip-components=1
+        rm pcre2.tar.bz2
+    build:
+      - |
+        export PKG_CONFIG_PATH=/usr/lib/pkgconfig
+
+        ./configure --prefix=/usr
+
+        make -j $(nproc)
+    install:
+      - |
+        make DESTDIR=/rootfs install
+finalize:
+  - from: /rootfs
+    to: /

--- a/qemu/qemu-guest-agent/pkg.yaml
+++ b/qemu/qemu-guest-agent/pkg.yaml
@@ -1,0 +1,72 @@
+name: qemu-guest-agent
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  - image: "{{ .PKGS_PREFIX }}/openssl:{{ .BUILD_ARG_PKGS }}"
+  - stage: pcre2
+  - stage: glib
+steps:
+  - sources:
+      - url: https://download.qemu.org/qemu-{{ .QEMU_VERSION }}.tar.xz
+        destination: qemu.tar.xz
+        sha256: f060abd435fbe6794125e2c398568ffc3cfa540042596907a8b18edca34cf6a5
+        sha512: 4e915d33a662bf55b09247fb85150be376c92270d3764e3d6470c452cb70cc558f54e84de5610dd60a9eb3ea02d5d4277b1ec75c9804967d278fa8361c7f9b9a
+    prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+      - |
+        tar -xf qemu.tar.xz --strip-components=1
+        rm qemu.tar.xz
+      - |
+        mkdir -p /usr/bin
+
+        ln -s /toolchain/bin/env /usr/bin/env
+        ln -s /toolchain/bin/python3 /toolchain/bin/python
+
+        pip3 install ninja
+    build:
+      - |
+        extra_args=( )
+
+        if [[ "${ARCH}" == aarch64 ]]; then
+          # FIXME: Workaround for “read-only segment has dynamic relocations” linking error.
+          extra_args+=( --disable-pie )
+        fi
+
+        export PKG_CONFIG_PATH=/usr/lib/pkgconfig
+
+        ./configure \
+          --static \
+          --prefix=/usr/local \
+          --localstatedir=/var \
+          --without-default-features \
+          --disable-system \
+          --disable-user \
+          --disable-docs \
+          --disable-install-blobs \
+          --enable-guest-agent \
+          --enable-stack-protector \
+          "${extra_args[@]}"
+
+        make -j $(nproc) qemu-ga
+    install:
+      - |
+        make DESTDIR=/rootfs install
+
+        container_root=/rootfs/usr/local/lib/containers/qemu-guest-agent
+        mkdir -p "${container_root}"
+
+        mv /rootfs/usr/local/bin/qemu-ga "${container_root}/qemu-ga"
+        rmdir /rootfs/usr/local/bin
+        rm -r /rootfs/usr/local/share/qemu
+        rmdir /rootfs/usr/local/share
+        rmdir /rootfs/var/run
+        rmdir /rootfs/var
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /
+  - from: /pkg/qemu-guest-agent.yaml
+    to: /rootfs/usr/local/etc/containers/

--- a/qemu/qemu-guest-agent/qemu-guest-agent.yaml
+++ b/qemu/qemu-guest-agent/qemu-guest-agent.yaml
@@ -1,0 +1,51 @@
+name: qemu-guest-agent
+depends:
+  - service: cri
+  - path: /dev/virtio-ports/org.qemu.guest_agent.0
+container:
+  entrypoint: ./qemu-ga
+  mounts:
+    # Shared libraries.
+    - source: /lib
+      destination: /lib
+      type: bind
+      options:
+        - bind
+        - ro
+    - source: /usr/lib
+      destination: /usr/lib
+      type: bind
+      options:
+        - bind
+        - ro
+    # State files.
+    - source: /var/run
+      destination: /var/run
+      type: bind
+      options:
+        - rshared
+        - rbind
+        - rw
+    # Device files.
+    - source: /dev
+      destination: /dev
+      type: bind
+      options:
+        - rshared
+        - rbind
+        - rw
+    # `/sbin/init` talks to `apid`.
+    - source: /system/run/apid/apid.sock
+      destination: /system/run/apid/apid.sock
+      type: bind
+      options:
+        - rshared
+        - rbind
+        - ro
+    - source: /sbin/init
+      destination: /sbin/shutdown
+      type: bind
+      options:
+        - bind
+        - ro
+restart: always

--- a/qemu/qemu-guest-agent/vars.yaml
+++ b/qemu/qemu-guest-agent/vars.yaml
@@ -1,0 +1,1 @@
+VERSION: "{{ .QEMU_VERSION }}"

--- a/qemu/vars.yaml
+++ b/qemu/vars.yaml
@@ -1,0 +1,6 @@
+# renovate: datasource=git-tags depName=https://github.com/qemu/qemu.git
+QEMU_VERSION: 8.0.2
+# renovate: datasource=git-tags depName=https://gitlab.gnome.org/GNOME/glib.git
+GLIB_VERSION: 2.76.3
+# renovate: datasource=github-releases extractVersion=^pcre2-(?<version>.*)$ depName=PCRE2Project/pcre2
+PCRE2_VERSION: 10.42


### PR DESCRIPTION
I haven't tested this at all yet since I haven't figured out yet what's the best way to do this.

cc @jabbas, since you mentioned this here https://github.com/siderolabs/talos/issues/3630#issuecomment-1399595011.


Try it using:

```yaml
machine:
  install:
    extensions:
      - image: docker.io/reitermarkus/qemu-guest-agent:8.0.2 
```
