### PR TITLE
release(v1.4.6): prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+## [Talos System Extensions 1.4.6](https://github.com/siderolabs/extensions/releases/tag/v1.4.6) (2023-06-28)
+
+Welcome to the v1.4.6 release of Talos System Extensions!
+
+See [Talos Linux documentation](https://www.talos.dev/v1.4/talos-guides/configuration/system-extensions/) for information on using system extensions.
+
+Please try out the release binaries and report any issues at
+https://github.com/siderolabs/extensions/issues.
+
+### Component Updates
+
+DRBD: 9.2.4
+
+
+### Contributors
+
+
+### Changes
+<details><summary>0 commit</summary>
+<p>
+
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+
+Previous release can be found at [v1.4.5](https://github.com/siderolabs/extensions/releases/tag/v1.4.5)
+
 ## [Talos System Extensions 1.4.5](https://github.com/siderolabs/extensions/releases/tag/v1.4.5) (2023-05-30)
 
 Welcome to the v1.4.5 release of Talos System Extensions!

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 # keep in sync with Pkgfile
 BLDR_RELEASE ?= v0.2.0-alpha.12
-PKGS ?= v1.4.1-11-g3e75ce2
+PKGS ?= v1.4.1-14-ge911ac5
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64,linux/arm64

--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@ format: v1alpha2
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
   LINUX_FIRMWARE_VERSION: "20230310" # update this when updating PKGS_VERSION in Makefile
-  DRBD_DRIVER_VERSION: 9.2.2 # update this when updating PKGS_VERSION in Makefile
+  DRBD_DRIVER_VERSION: 9.2.4 # update this when updating PKGS_VERSION in Makefile
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/extensions

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -6,7 +6,7 @@ github_repo = "siderolabs/extensions"
 match_deps = "^github.com/((talos-systems|siderolabs)/[a-zA-Z0-9-]+)$"
 
 # previous release
-previous = "v1.4.3"
+previous = "v1.4.5"
 
 pre_release = false
 
@@ -15,5 +15,12 @@ See [Talos Linux documentation](https://www.talos.dev/v1.4/talos-guides/configur
 """
 
 [notes]
+
+    [notes.updates]
+        title = "Component Updates"
+        description="""\
+DRBD: 9.2.4
+"""
+
 
 [make_deps]


### PR DESCRIPTION
This is the official v1.4.6 release.