### PR TITLE
fix: use correct exit status in `nut-client` patch

### DIFF
--- a/power/nut-client/nut-client.yaml
+++ b/power/nut-client/nut-client.yaml
@@ -10,6 +10,7 @@ container:
   args:
     - -F
   mounts:
+    # Shared libraries.
     - source: /lib
       destination: /lib
       type: bind
@@ -22,24 +23,23 @@ container:
       options:
         - bind
         - ro
-    # config via .machine.files
+    # Configuration provided via `.machine.files`.
     - source: /var/etc/nut
       destination: /usr/local/etc/nut
       type: bind
       options:
         - bind
         - ro
-    # /sbin/init talks to apid
+    # `/sbin/init` talks to `apid`.
     - source: /system/run/apid/apid.sock
       destination: /system/run/apid/apid.sock
       type: bind
       options:
         - rshared
         - rbind
-        - rw
-    # symlinked to /sbin/poweroff
+        - ro
     - source: /sbin/init
-      destination: /sbin/init
+      destination: /sbin/poweroff
       type: bind
       options:
         - bind

--- a/power/nut-client/patches/replace_system.patch
+++ b/power/nut-client/patches/replace_system.patch
@@ -8,25 +8,24 @@
  
  #include "nut_stdint.h"
  #include "upsclient.h"
-@@ -1874,6 +1875,23 @@
+@@ -1874,6 +1875,22 @@
  static void runparent(int fd)
  	__attribute__((noreturn));
  
 +static int runcmd(const char *cmd)
 +{
-+	int	sret, status;
-+	pid_t pid;
-+	char *argv[] = {cmd, NULL};
-+	char *env[] = {NULL};
++	// TODO: Support tokenizing `cmd`.
++	const char *argv[] = {cmd, NULL};
++	const char *env[] = {NULL};
 +
-+	/* TODO support tokenizing cmd */
-+	sret = posix_spawn(&pid, cmd, NULL, NULL, argv, env);
++	pid_t pid = 0;
++	int sret = posix_spawn(&pid, cmd, NULL, NULL, argv, env);
 +	if (sret != 0)
-+		/* parent */
-+		exit(EXIT_SUCCESS);
++		return -1;
 +
-+	sret = waitpid(pid, &status, 0);
-+	return status;
++	int status;
++	waitpid(pid, &status, 0);
++	return WEXITSTATUS(status);
 +}
 +
  static void runparent(int fd)

--- a/power/nut-client/pkg.yaml
+++ b/power/nut-client/pkg.yaml
@@ -20,8 +20,8 @@ steps:
         # no shell for you
         patch -p1 < /pkg/patches/replace_system.patch
       - |
-        mkdir -p /usr/bin \
-            && ln -sf /toolchain/bin/env /usr/bin/env
+        mkdir -p /usr/bin
+        ln -sf /toolchain/bin/env /usr/bin/env
 
         # Create symlinks for files used when building.
         ln -s /toolchain/bin/pkg-config /usr/bin/pkg-config
@@ -76,11 +76,6 @@ steps:
 
         # TODO replace /usr/bin/wall with either a wrapper for printk or a
         # Go cmd to log to Talos Events
-
-        # /sbin/init is bind mounted in nut-client.yaml
-        pushd "$containerRoot/sbin"
-        ln -sv ./init poweroff
-        popd
 
         # cleanup
         rm -rf /rootfs/usr/local/bin


### PR DESCRIPTION
Extracted from https://github.com/siderolabs/extensions/pull/173.

