### PR TITLE
chore: use machined for shutdown calls

### DIFF
--- a/power/nut-client/manifest.yaml
+++ b/power/nut-client/manifest.yaml
@@ -7,4 +7,4 @@ metadata:
     This system extension provides the network-ups-tools upsmon service.
   compatibility:
     talos:
-      version: ">= v1.2.0"
+      version: ">= v1.5.0"

--- a/power/nut-client/nut-client.yaml
+++ b/power/nut-client/nut-client.yaml
@@ -5,6 +5,7 @@ depends:
     - addresses
     - connectivity
     - etcfiles
+  - path: /system/run/machined/machine.sock
 container:
   entrypoint: ./upsmon
   args:
@@ -30,9 +31,9 @@ container:
       options:
         - bind
         - ro
-    # `/sbin/init` talks to `apid`.
-    - source: /system/run/apid/apid.sock
-      destination: /system/run/apid/apid.sock
+    # `/sbin/init` talks to `machined`.
+    - source: /system/run/machined/machine.sock
+      destination: /system/run/machined/machine.sock
       type: bind
       options:
         - rshared

--- a/qemu/qemu-guest-agent/pkg.yaml
+++ b/qemu/qemu-guest-agent/pkg.yaml
@@ -25,8 +25,7 @@ steps:
         ln -s /toolchain/bin/python3 /toolchain/bin/python
 
         pip3 install ninja
-    build:
-      - |
+
         extra_args=( )
 
         if [[ "${ARCH}" == aarch64 ]]; then
@@ -48,7 +47,8 @@ steps:
           --enable-guest-agent \
           --enable-stack-protector \
           "${extra_args[@]}"
-
+    build:
+      - |
         make -j $(nproc) qemu-ga
     install:
       - |

--- a/qemu/qemu-guest-agent/qemu-guest-agent.yaml
+++ b/qemu/qemu-guest-agent/qemu-guest-agent.yaml
@@ -1,6 +1,7 @@
 name: qemu-guest-agent
 depends:
   - service: cri
+  - path: /system/run/machined/machine.sock
   - path: /dev/virtio-ports/org.qemu.guest_agent.0
 container:
   entrypoint: ./qemu-ga
@@ -34,9 +35,9 @@ container:
         - rshared
         - rbind
         - rw
-    # `/sbin/init` talks to `apid`.
-    - source: /system/run/apid/apid.sock
-      destination: /system/run/apid/apid.sock
+    # `/sbin/init` talks to `machined`.
+    - source: /system/run/machined/machine.sock
+      destination: /system/run/machined/machine.sock
       type: bind
       options:
         - rshared


### PR DESCRIPTION
Use machined socket for `shutdown`, `poweroff` alias.

Depends on: https://github.com/siderolabs/talos/pull/7489