### PR TITLE
feat: update extension spec allowlist for opengl

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ Any paths in the `rootfs` should be contained within the following hierarchies:
 - `/lib64/ld-linux-x86-64.so.2`
 - `/usr/etc/udev/rules.d/`
 - `/usr/local/`
+- `/usr/share/glvnd/`
+- `/usr/share/egl/`
+- `/etc/vulkan/`
 
 ## Dependency Diagram
 


### PR DESCRIPTION
NVIDIA OpenGL/Vulkan files needs to be explicitly in the new locations added.

Ref: https://github.com/NVIDIA/nvidia-container-toolkit/blob/v1.13.5/internal/discover/graphics.go#L83-L89

```bash
root@2f51980391de:/tmp/NVIDIA-Linux-x86_64-535.54.03# find /usr /etc -type f -name "*.json"
/usr/share/glvnd/egl_vendor.d/10_nvidia.json
/usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json
/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
/usr/lib/nvidia/egl_dummy_vendor.json
/etc/vulkan/icd.d/nvidia_icd.json
/etc/vulkan/implicit_layer.d/nvidia_layers.json
```

`egl_dummy_vendor.json` can be ignored.

Partial fix for #171