### PR TITLE
feat: microcode updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 # keep in sync with Pkgfile
 BLDR_RELEASE ?= v0.2.0
-PKGS ?= v1.5.0
+PKGS ?= v1.5.0-1-g8a2227d
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64,linux/arm64

--- a/Pkgfile
+++ b/Pkgfile
@@ -4,7 +4,7 @@ format: v1alpha2
 
 vars:
   PKGS_PREFIX: ghcr.io/siderolabs
-  LINUX_FIRMWARE_VERSION: "20230625" # update this when updating PKGS_VERSION in Makefile
+  LINUX_FIRMWARE_VERSION: "20230804" # update this when updating PKGS_VERSION in Makefile
   DRBD_DRIVER_VERSION: 9.2.4 # update this when updating PKGS_VERSION in Makefile
   ZFS_DRIVER_VERSION: 2.1.12 # update this when updating PKGS_VERSION in Makefile
 

--- a/firmware/intel-ucode/pkg.yaml
+++ b/firmware/intel-ucode/pkg.yaml
@@ -7,8 +7,8 @@ steps:
   - sources:
       - url: https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/refs/tags/microcode-{{ .INTEL_UCODE_VERSION }}.tar.gz
         destination: intel-ucode.tar.gz
-        sha256: 894d822d2347222a2595d4fc47d358e01d35a54780123100c317dfc31b1b0cc9
-        sha512: 460e46d20f71df1247affa2ca397b961ce3d77e3456144c6b7358e48c3239e9c077ff4c512b0c4b7d9a86f33fed094db8b3ac65b1a4047bb853212848d929639
+        sha256: fe49bb719441f20335ed6004090ab38cdc374134d36d4f5d30be7ed93b820313
+        sha512: 8316eb9d35b315e630c6c9fab1ba601b91e72cc42926ef14e7c2b77e7025d276ae06c143060f44cd1a873d3879c067d11ad82e1886c796e6be6bf466243ad85b
     prepare:
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml

--- a/firmware/vars.yaml
+++ b/firmware/vars.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-releases extractVersion=^microcode-(?<version>.*)$ depName=intel/Intel-Linux-Processor-Microcode-Data-Files
-INTEL_UCODE_VERSION: 20230613
+INTEL_UCODE_VERSION: 20230808

--- a/network/tailscale/pkg.yaml
+++ b/network/tailscale/pkg.yaml
@@ -9,8 +9,8 @@ steps:
   - sources:
       - url: https://github.com/tailscale/tailscale/archive/refs/tags/v{{ .TAILSCALE_VERSION }}.tar.gz
         destination: tailscale.tar.gz
-        sha256: dc230cf3ac290140e573268a6e8f17124752ef064c8d3a86765a9dbb6f1bd354
-        sha512: d3bd5adf469cb2cc5a6e7df08fd9327d1b2492f7779dbf9e4158cc137dfcbe7c07c51f10adc142d5cd2827b837633722b585f2f20dfdd5821703fc9e4aed333d
+        sha256: a567bafec720869faa25eb1886dac1b519679c8dbe5762d1e9cdb653898df076
+        sha512: cecaa216b1f451b65e826856f630e5dd8ef9bbd85684602450e71f0f46b6b1b97bf20a0b7c401a72c354a5a9404386d6bd03350da2a65fb4e358320763d93ab4
     prepare:
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml

--- a/network/vars.yaml
+++ b/network/vars.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-releases extractVersion=^v(?<version>.*)$ depName=tailscale/tailscale
-TAILSCALE_VERSION: 1.44.0
+TAILSCALE_VERSION: 1.46.1

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.mod
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.mod
@@ -2,4 +2,4 @@ module nvidia-container-runtime-wrapper
 
 go 1.20
 
-require golang.org/x/sys v0.10.0
+require golang.org/x/sys v0.11.0

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.sum
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
+golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
@@ -2,4 +2,4 @@ module nvidia-persistenced-wrapper
 
 go 1.20
 
-require golang.org/x/sys v0.10.0
+require golang.org/x/sys v0.11.0

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
+golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/storage/iscsi-tools/iscsid-wrapper/go.mod
+++ b/storage/iscsi-tools/iscsid-wrapper/go.mod
@@ -2,4 +2,4 @@ module iscsid-wrapper
 
 go 1.20
 
-require golang.org/x/sys v0.10.0
+require golang.org/x/sys v0.11.0

--- a/storage/iscsi-tools/iscsid-wrapper/go.sum
+++ b/storage/iscsi-tools/iscsid-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
+golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
AMD ucode (via Linux firmware).
Intel: https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20230808 
Tailscale: 1.46.1