### PR TITLE
docs: fix usb modem readme

### DIFF
--- a/drivers/usb-modem/README.md
+++ b/drivers/usb-modem/README.md
@@ -27,7 +27,7 @@ machine:
       - name: cdc_subset
       - name: zaurus
       - name: cdc_wdm
-      - name: rtl8153_ecm
+      - name: r8153_ecm
 ```
 
 ## Verifiying


### PR DESCRIPTION
Fix the wrong module name name in USB modem drivers README.