### PR TITLE
feat: add btrfs storage extension

### DIFF
--- a/.drone.yaml
+++ b/.drone.yaml
@@ -66,7 +66,7 @@ steps:
       - name: buildx
         path: /root/.docker/buildx
     depends_on:
-      - setup-ci
+      - build-pull-request
 
   - name: build-and-publish
     image: autonomy/build-container:latest

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 # keep in sync with Pkgfile
 BLDR_RELEASE ?= v0.2.0
-PKGS ?= v1.5.0-6-g2f2c9cd
+PKGS ?= v1.6.0-alpha.0-7-g2e1c0b9
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ All system extensions provided by Sidero Labs can be found in the [ghcr.io regis
 
 ### Storage
 
-| Name                                | Image                                                                                                 | Description        | Version Format                     |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------ | ---------------------------------- |
-| [iscsi-tools](storage/iscsi-tools/) | [ghcr.io/siderolabs/iscsi-tools](https://github.com/siderolabs/extensions/pkgs/container/iscsi-tools) | Open iSCSI tools   | `v0.1.0`                           |
-| [drbd](storage/drbd/)               | [ghcr.io/siderolabs/drbd](https://github.com/siderolabs/extensions/pkgs/container/drbd)               | DRBD driver module | `upstream version`-`talos version` |
-| [zfs](storage/zfs/)                 | [ghcr.io/siderolabs/zfs](https://github.com/siderolabs/extensions/pkgs/container/zfs)                 | ZFS driver module  | `upstream version`-`talos version` |
+| Name                                | Image                                                                                                 | Description         | Version Format                     |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------- | ---------------------------------- |
+| [iscsi-tools](storage/iscsi-tools/) | [ghcr.io/siderolabs/iscsi-tools](https://github.com/siderolabs/extensions/pkgs/container/iscsi-tools) | Open iSCSI tools    | `v0.1.0`                           |
+| [drbd](storage/drbd/)               | [ghcr.io/siderolabs/drbd](https://github.com/siderolabs/extensions/pkgs/container/drbd)               | DRBD driver module  | `upstream version`-`talos version` |
+| [zfs](storage/zfs/)                 | [ghcr.io/siderolabs/zfs](https://github.com/siderolabs/extensions/pkgs/container/zfs)                 | ZFS driver module   | `upstream version`-`talos version` |
+| [btrfs](storage/btrfs/)             | [ghcr.io/siderolabs/btrfs](https://github.com/siderolabs/extensions/pkgs/container/btrfs)             | BTRFS driver module | `talos version`                    |
 
 ### Power
 

--- a/storage/btrfs/README.md
+++ b/storage/btrfs/README.md
@@ -1,0 +1,17 @@
+# btrfs
+
+This extension provides kernel modules needed to mount btrfs filesystems.
+
+## Installation
+
+Add the extension to your machine config and enable the modules.
+
+```yaml
+machine:
+  install:
+    extensions:
+      - image: ghcr.io/siderolabs/btrfs:<VERSION>
+  kernel:
+    modules:
+      - name: btrfs
+```

--- a/storage/btrfs/manifest.yaml
+++ b/storage/btrfs/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: btrfs
+  version: "$VERSION"
+  author: Enno Boland
+  description: |
+    This system extension provides kernel module driver for BTRFS built against a specific Talos version.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"

--- a/storage/btrfs/pkg.yaml
+++ b/storage/btrfs/pkg.yaml
@@ -1,0 +1,22 @@
+name: btrfs
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  # The pkgs version for a particular release of Talos as defined in
+  # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
+  - image: "{{ .PKGS_PREFIX }}/btrfs-pkg:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+  - install:
+      - |
+        mkdir -p /rootfs/lib/modules
+
+        cp -R /lib/modules/* /rootfs/lib/modules
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/storage/btrfs/vars.yaml
+++ b/storage/btrfs/vars.yaml
@@ -1,0 +1,1 @@
+VERSION: "{{ .BUILD_ARG_TAG }}"


### PR DESCRIPTION
Part 2 of 2 to add a btrfs extension to talos.

tracking issue: https://github.com/siderolabs/extensions/issues/199