### PR TITLE
chore: enable pushing of non-free packages

### DIFF
--- a/.drone.yaml
+++ b/.drone.yaml
@@ -79,6 +79,7 @@ steps:
     commands:
       - docker login ghcr.io --username "$${GHCR_USERNAME}" --password "$${GHCR_PASSWORD}"
       - make PUSH=true
+      - make nonfree PUSH=true
     when:
       event:
         exclude:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 # keep in sync with Pkgfile
 BLDR_RELEASE ?= v0.2.0
-PKGS ?= v1.5.0-1-g8a2227d
+PKGS ?= v1.5.0-4-gac36033
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64,linux/arm64
@@ -61,7 +61,8 @@ TARGETS = \
 # Temporarily disabled, as mellanox-ofed fails to build with Linux 6.1
 #		mellanox-ofed \
 
-NONFREE_TARGETS =
+NONFREE_TARGETS = \
+	nonfree-kmod-nvidia \
 
 all: $(TARGETS) ## Builds all known pkgs.
 

--- a/nvidia-gpu/nonfree/kmod-nvidia/files/nvidia.conf
+++ b/nvidia-gpu/nonfree/kmod-nvidia/files/nvidia.conf
@@ -1,0 +1,4 @@
+blacklist nvidia
+blacklist nvidia_uvm
+blacklist nvidia_drm
+blacklist nvidia_modeset

--- a/nvidia-gpu/nonfree/kmod-nvidia/manifest.yaml
+++ b/nvidia-gpu/nonfree/kmod-nvidia/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: nonfree-kmod-nvidia
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides nvidia proprietary kernel modules built against a specific Talos version.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"

--- a/nvidia-gpu/nonfree/kmod-nvidia/pkg.yaml
+++ b/nvidia-gpu/nonfree/kmod-nvidia/pkg.yaml
@@ -1,0 +1,25 @@
+name: nonfree-kmod-nvidia
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+ - stage: base
+# The pkgs version for a particular release of Talos as defined in
+# https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
+ - image: "{{ .PKGS_PREFIX }}/nonfree-kmod-nvidia:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+  - install:
+      - |
+        mkdir -p /rootfs/lib/modules \
+          /rootfs/usr/local/lib/modprobe.d
+
+        cp /pkg/files/nvidia.conf /rootfs/usr/local/lib/modprobe.d/nvidia.conf
+
+        cp -R /lib/modules/* /rootfs/lib/modules
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/nvidia-gpu/nonfree/kmod-nvidia/vars.yaml
+++ b/nvidia-gpu/nonfree/kmod-nvidia/vars.yaml
@@ -1,0 +1,2 @@
+# the first part is the driver version and the second the talos version for which the module is built against
+VERSION: "{{ .NVIDIA_DRIVER_VERSION }}-{{ .BUILD_ARG_TAG }}"


### PR DESCRIPTION
At the moment it is kmod-nvidia.

Ref: https://github.com/siderolabs/pkgs/pull/774

Part of: https://github.com/siderolabs/talos/issues/7611