### PR TITLE
fix: nonfree nvidia pkg name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 # keep in sync with Pkgfile
 BLDR_RELEASE ?= v0.2.0
-PKGS ?= v1.5.0-4-gac36033
+PKGS ?= v1.5.0-6-g2f2c9cd
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64,linux/arm64

--- a/nvidia-gpu/nonfree/kmod-nvidia/pkg.yaml
+++ b/nvidia-gpu/nonfree/kmod-nvidia/pkg.yaml
@@ -5,7 +5,7 @@ dependencies:
  - stage: base
 # The pkgs version for a particular release of Talos as defined in
 # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
- - image: "{{ .PKGS_PREFIX }}/nonfree-kmod-nvidia:{{ .BUILD_ARG_PKGS }}"
+ - image: "{{ .PKGS_PREFIX }}/nonfree-kmod-nvidia-pkg:{{ .BUILD_ARG_PKGS }}"
 steps:
   - prepare:
       - |


### PR DESCRIPTION
Fix nonfree to refer `-pkg` module.
Currently it was referring itself.