### PR TITLE
chore: minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ space = $(empty) $(empty)
 TARGETS = \
 		amd-ucode \
 		bnx2-bnx2x \
+		btrfs \
 		drbd \
 		gasket-driver \
 		gvisor \

--- a/storage/iscsi-tools/iscsid-wrapper/main.go
+++ b/storage/iscsi-tools/iscsid-wrapper/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -30,7 +29,7 @@ func main() {
 			initiatorName := fmt.Sprintf("InitiatorName=%s", cmdOut.String())
 			log.Printf("iscsid-wrapper: writing %s to /etc/iscsi/initiatorname.iscsi", initiatorName)
 
-			if err := ioutil.WriteFile("/etc/iscsi/initiatorname.iscsi", []byte(initiatorName), 0o644); err != nil {
+			if err := os.WriteFile("/etc/iscsi/initiatorname.iscsi", []byte(initiatorName), 0o644); err != nil {
 				log.Printf("iscsi-iname: error saving iscsi initiatorname %v\n", err)
 			}
 		}


### PR DESCRIPTION
`btrfs` was missing from `Makefile`.
Use `os` package instead of deprecated `io/ioutil`.