### PR TITLE
chore: revert nvidia bumps from #220

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -49,8 +49,6 @@ ZFS extensions now also ship zfs-tools and an extension service that imports all
         title = "Component Updates"
         description = """\
 * DRBD: 9.2.5
-* nvidia-container-toolkit: v1.14.0
-* libnvidia-container: v1.14.0
 * QEMU agent: v8.1.0
 * Tailscale: 1.48.1
 """

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/pkg.yaml
@@ -6,6 +6,7 @@ install:
   - bash
   - go
   - coreutils
+  - sed
   - curl
   - rpcsvc-proto
   - patch
@@ -29,16 +30,16 @@ steps:
   - sources:
       - url: https://gitlab.com/nvidia/container-toolkit/libnvidia-container/-/archive/{{ .LIBNVIDIA_CONTAINER_VERSION }}/libnvidia-container-{{ .LIBNVIDIA_CONTAINER_VERSION }}.tar.gz
         destination: libnvidia-container.tar.gz
-        sha256: e9cff43bbbe5d6b0e394713f7711b1ec7b0c2878c827f140ee350e44de4d1f4b
-        sha512: 79d55974b85f9596253f60821319f94652de1fc8f0a21f23ada65905e4b2547b3f594273c77b6d57a37a3c2b11ff0ca84f6efb4311c7be3b4b2066d53181e39c
+        sha256: 4beebedd045468e8174895f5d4a563f7880cf7a10f062d996719c061fcdaa0db
+        sha512: a16f163cb8689f4b6279bed1a5965ee4c56f413918cae6acf272ca5adf7dd929818d977dd6657ce496abeb842b56e03bfd83bda828a7b953625b2999ac174b93
     env:
       REVISION: {{ .LIBNVIDIA_CONTAINER_REF }}
-      GIT_TAG: {{ .LIBNVIDIA_CONTAINER_VERSION | replace "v" "" }}
       WITH_NVCGO: yes
       WITH_LIBELF: yes
       WITH_TIRPC: no # setting no means we'll use the system libtirpc
       WITH_SECCOMP: yes
       PKG_CONFIG_PATH: /usr/local/lib/pkgconfig # to find runtime libraries compiled in extensions (libseccomp)
+      PATH: "/usr/bin:{{ .PATH }}" # bldr doesn't have /usr/bin in PATH
     prepare:
       - |
         mkdir libnvidia-container

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/pkg.yaml
@@ -12,8 +12,8 @@ steps:
   - sources:
       - url: https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/archive/{{ .CONTAINER_TOOLKIT_VERSION }}/container-toolkit-{{ .CONTAINER_TOOLKIT_VERSION }}.tar.gz
         destination: container-toolkit.tar.gz
-        sha256: 523d6341ad808f2513b20918175245be1c342f8a5ff187777c6e26e4197da17e
-        sha512: 39774643b3e9489f216649515cd9058d6de7e9d57019437e2c286802710e59d207becfcdb16489456c3043d057a0fb841e86810006e5cf283628b06e2863cee8
+        sha256: b9ee6f96addbcbace9503f29551b4f3c42d76293a0d54f5c6009971909dac0fc
+        sha512: 69bfac15d8be2797b09dda35650a90dcb2c24ca7a5107c3df5946840a55df8dc62cb5cc46f172169ee3e8447c416733848b513b92dc512df35e0aad7c77e5c1e
     env:
       GIT_COMMIT: {{ substr 0 7 .CONTAINER_TOOLKIT_REF }} # build is using short sha
     prepare:

--- a/nvidia-gpu/vars.yaml
+++ b/nvidia-gpu/vars.yaml
@@ -2,11 +2,11 @@
 # renovate: datasource=github-releases depName=nvidia/open-gpu-kernel-modules
 NVIDIA_DRIVER_VERSION: 535.54.03
 # renovate: datasource=git-tags depName=https://gitlab.com/nvidia/container-toolkit/container-toolkit.git
-CONTAINER_TOOLKIT_VERSION: v1.14.0
-CONTAINER_TOOLKIT_REF: f2bd3173d44938eadb73252b866a9b3a7f44b8c6
+CONTAINER_TOOLKIT_VERSION: v1.13.5
+CONTAINER_TOOLKIT_REF: 6b8589dcb4dead72ab64f14a5912886e6165c079
 # renovate: datasource=git-tags depName=https://gitlab.com/nvidia/container-toolkit/libnvidia-container.git
-LIBNVIDIA_CONTAINER_VERSION: v1.14.0
-LIBNVIDIA_CONTAINER_REF: 6a24508dff6cb36841114ff4c1287cd29ded72af
+LIBNVIDIA_CONTAINER_VERSION: v1.13.5
+LIBNVIDIA_CONTAINER_REF: 66607bd046341f7aad7de80a9f022f122d1f2fce
 # renovate: datasource=docker versioning=docker depName=cgr.dev/chainguard/wolfi-base
 WOLFI_BASE_REF: sha256:f73a3360466ecc4d6df3f451d7d5c4c49663096e158848ddbc9603c52a47bffe
 # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go


### PR DESCRIPTION
Revert nvidia bumps from #220. The extensions-test fail and there's not much debug info available for now.