### PR TITLE
chore: add extensions catalog

### DIFF
--- a/.drone.yaml
+++ b/.drone.yaml
@@ -80,6 +80,7 @@ steps:
       - docker login ghcr.io --username "$${GHCR_USERNAME}" --password "$${GHCR_PASSWORD}"
       - make PUSH=true
       - make nonfree PUSH=true
+      - make extensions PUSH=true
     when:
       event:
         exclude:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _out/
+internal/extensions/image-digests

--- a/internal/extensions/pkg.yaml
+++ b/internal/extensions/pkg.yaml
@@ -1,0 +1,6 @@
+# this is a meta-package that contains a list of extension images for each version
+name: extensions
+variant: scratch
+finalize:
+  - from: /pkg/image-digests
+    to: /image-digests


### PR DESCRIPTION
Push the list of all images built for a specific version of extension to the `extensions` image. This way one can get a list of versions of extensions compatible with Talos version.

Update `sign-images` step to use `cosign` interactive flow, this is easier. Skip signing already signed images.