### PR TITLE
backport: chore: add extensions catalog

### DIFF
--- a/.drone.yaml
+++ b/.drone.yaml
@@ -80,6 +80,7 @@ steps:
       - docker login ghcr.io --username "$${GHCR_USERNAME}" --password "$${GHCR_PASSWORD}"
       - make PUSH=true
       - make nonfree PUSH=true
+      - make extensions PUSH=true
     when:
       event:
         exclude:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _out/
+internal/extensions/image-digests

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 SOURCE_DATE_EPOCH ?= "1642703752"
 ARTIFACTS ?= _out/
 OPERATING_SYSTEM := $(shell uname -s | tr "[:upper:]" "[:lower:]")
-GOARCH :=$(shell uname -m | tr '[:upper:]' '[:lower:]')
+GOARCH := $(shell uname -m | tr '[:upper:]' '[:lower:]')
+EXTENSIONS_IMAGE_REF := $(REGISTRY)/$(USERNAME)/extensions:$(TAG)
 
 ifeq ($(GOARCH),x86_64)
 GOARCH := amd64
@@ -69,6 +70,11 @@ all: $(TARGETS) ## Builds all known pkgs.
 .PHONY: nonfree
 nonfree: $(NONFREE_TARGETS) ## Builds all known non-free pkgs.
 
+.PHONY: extensions
+extensions: internal/extensions/image-digests ## Builds a list of generated extension images as an image.
+	@$(MAKE) docker-$@ \
+		TARGET_ARGS="--tag=$(EXTENSIONS_IMAGE_REF) --push=$(PUSH)"
+
 .PHONY: help
 help: ## This help menu.
 	@grep -E '^[a-zA-Z%_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -96,11 +102,17 @@ extensions-metadata: $(ARTIFACTS)/bldr
 	@$(foreach target,$(TARGETS),echo $(REGISTRY)/$(USERNAME)/$(target):$(shell $(ARTIFACTS)/bldr eval --target $(target) --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null) >> _out/extensions-metadata;)
 	@$(foreach target,$(NONFREE_TARGETS),echo $(REGISTRY)/$(USERNAME)/$(target):$(shell $(ARTIFACTS)/bldr eval --target $(target) --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null) >> _out/extensions-metadata;)
 
-image-list: extensions-metadata ## Prints a list of all images built by this Makefile with digests.
-	@cat _out/extensions-metadata | xargs -I{} sh -c 'echo {}@$$(crane digest {})'
+.PHONY: internal/extensions/image-digests
+internal/extensions/image-digests: extensions-metadata ## Stores a list of all images built by this Makefile with digests.
+	@cat _out/extensions-metadata | xargs -I{} sh -c 'echo {}@$$(crane digest {})' > internal/extensions/image-digests
 
+.PHONY: sign-images
 sign-images: ## Run cosign to sign all images built by this Makefile.
-	@$(MAKE) --quiet image-list | xargs -I{} sh -c 'cosign sign --yes {}'
+	@for image in $(shell crane export $(EXTENSIONS_IMAGE_REF) | tar x --to-stdout image-digests) $(EXTENSIONS_IMAGE_REF)@$$(crane digest $(EXTENSIONS_IMAGE_REF)); do \
+		echo '==>' $$image; \
+		cosign verify $$image --certificate-identity-regexp '@siderolabs\.com$$' --certificate-oidc-issuer https://accounts.google.com || \
+			cosign sign --yes $$image; \
+	done
 
 .PHONY: deps.png
 deps.png: $(ARTIFACTS)/bldr

--- a/internal/extensions/pkg.yaml
+++ b/internal/extensions/pkg.yaml
@@ -1,0 +1,6 @@
+# this is a meta-package that contains a list of extension images for each version
+name: extensions
+variant: scratch
+finalize:
+  - from: /pkg/image-digests
+    to: /image-digests


### PR DESCRIPTION
Push the list of all images built for a specific version of extension to the `extensions` image. This way one can get a list of versions of extensions compatible with Talos version.

Update `sign-images` step to use `cosign` interactive flow, this is easier. Skip signing already signed images.

Signed-off-by: Andrey Smirnov <andrey.smirnov@siderolabs.com>
(cherry picked from commit 8fa50a2fa25f34f38f7bf4f393be0c618f5b8bb7)