### PR TITLE
ikheaders extension for kernel headers

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -15,6 +15,7 @@ spec:
     - gvisor
     - hello-world-service
     - i915-ucode
+    - ikheaders
     - intel-ice-firmware
     - intel-ucode
     - iscsi-tools

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ TARGETS += gasket-driver
 TARGETS += gvisor
 TARGETS += hello-world-service
 TARGETS += i915-ucode
+TARGETS += ikheaders
 TARGETS += intel-ice-firmware
 TARGETS += intel-ucode
 TARGETS += iscsi-tools

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ cosign verify --certificate-identity-regexp '@siderolabs\.com$' --certificate-oi
 | Name                            | Image                                                                                             | Description                        | Version Format     |
 | ------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------ |
 | [binfmt-misc](misc/binfmt-misc) | [ghcr.io/siderolabs/binfmt-misc](https://github.com/siderolabs/extensions/pkgs/container/binfmt-misc) | Miscellaneous Binary Format | `talos version`                                       |
+| [ikheaders](misc/ikheaders/)    | [ghcr.io/siderolabs/ikheaders](https://github.com/siderolabs/extensions/pkgs/container/ikheaders)     | Kernel headers module       | `talos version`                                       |
 
 ### Network
 

--- a/misc/ikheaders/README.md
+++ b/misc/ikheaders/README.md
@@ -1,0 +1,13 @@
+# ikheaders extension
+
+## Installation
+
+See [Installing Extensions](https://github.com/siderolabs/extensions#installing-extensions).
+
+## Usage
+
+Provides:
+
+* `kheaders`
+
+This module provides a way to get the kernel headers for the running kernel.

--- a/misc/ikheaders/files/modules.txt
+++ b/misc/ikheaders/files/modules.txt
@@ -1,0 +1,4 @@
+modules.order
+modules.builtin
+modules.builtin.modinfo
+kernel/drivers/kernel/kheaders.ko

--- a/misc/ikheaders/manifest.yaml
+++ b/misc/ikheaders/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: ikheaders
+  version: "$VERSION"
+  author: SideroLabs
+  description: |
+    This system extension provides the Linux kernel headers module.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"

--- a/misc/ikheaders/pkg.yaml
+++ b/misc/ikheaders/pkg.yaml
@@ -1,0 +1,29 @@
+name: ikheaders
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  # The pkgs version for a particular release of Talos as defined in
+  # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
+  - image: "{{ .PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+  - install:
+      - |
+        export KERNELRELEASE=$(find /lib/modules -type d -name "*-talos" -exec basename {} \+)
+
+        mkdir -p /rootfs
+
+        xargs -a /pkg/files/modules.txt -I {} install -D /lib/modules/${KERNELRELEASE}/{} /rootfs/lib/modules/${KERNELRELEASE}/{}
+        depmod -b /rootfs ${KERNELRELEASE}
+  - test:
+      - |
+        # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping
+        find /rootfs/lib/modules -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/misc/ikheaders/vars.yaml
+++ b/misc/ikheaders/vars.yaml
@@ -1,0 +1,1 @@
+VERSION: "{{ .BUILD_ARG_TAG }}"

--- a/reproducibility/pkg.yaml
+++ b/reproducibility/pkg.yaml
@@ -17,6 +17,8 @@ dependencies:
   # - stage: chelsio-firmware
   # drbd can be ignored from reproducibility test since it's kernel modules copied from pkgs
   # - stage: drbd
+  # ikheaders can be ignored from reproducibility test since it's kernel modules copied from pkgs
+  # - stage: ikheaders
 
   - stage: fuse3
 


### PR DESCRIPTION
Companion commit to https://github.com/siderolabs/pkgs/pull/832

Contains the work to make an extension from the `kheaders` module for use in Talos, Details on the exact usecase are in the other PR