### PR TITLE
fix: iscsi-tools install `prefix`

### DIFF
--- a/storage/iscsi-tools/iscsid.yaml
+++ b/storage/iscsi-tools/iscsid.yaml
@@ -61,6 +61,13 @@ container:
       options:
         - bind
         - ro
+    - source: /var/lib/iscsi
+      destination: /var/lib/iscsi
+      type: bind
+      options:
+        - rshared
+        - rbind
+        - rw
     - source: /run/lock/iscsi
       destination: /run/lock/iscsi
       type: bind

--- a/storage/iscsi-tools/open-iscsi/pkg.yaml
+++ b/storage/iscsi-tools/open-iscsi/pkg.yaml
@@ -48,7 +48,9 @@ steps:
         meson setup \
           -Db_lto=true \
           -Dno_systemd=true \
-          -Drulesdir="/usr/local/etc/udev/rules.d" \
+          -Dprefix=/usr/local \
+          -Discsi_sbindir=/usr/local/sbin \
+          -Drulesdir=/usr/local/etc/udev/rules.d \
           -Dc_args="$CFLAGS -I/usr/local/include -DNO_SYSTEMD -DGLOB_ONLYDIR=0" \
           output
 
@@ -59,11 +61,9 @@ steps:
         DESTDIR=/rootfs ninja -C output install
 
         # cleanup
-        rm -rf /rootfs/usr/local/share
-        rm -rf /rootfs/usr/local/include
-        rm -rf /rootfs/usr/local/lib/pkgconfig
-        rm -rf /rootfs/usr/local/etc/iscsi/ifaces
-        rm -rf /rootfs/etc
+        # we generate a one time initiatorname.iscsi when the iscsid-wrapper starts.
+        rm -rf /rootfs/usr/local/{etc/iscsi/initiatorname.iscsi,share,include,pkgconfig}
+        rm -rf /rootfs/var/lib/iscsi
 
         cp /pkg/files/passwd /rootfs/usr/local/etc/passwd
 finalize:


### PR DESCRIPTION
Fixes the `iscsi-tools` install prefix to be `/usr/local`. This broke when moving from `make` to `meson`.