### PR TITLE
Bump Intel microcode to 20231114 (CVE-2023-23583)

### DIFF
--- a/firmware/intel-ucode/pkg.yaml
+++ b/firmware/intel-ucode/pkg.yaml
@@ -7,8 +7,8 @@ steps:
   - sources:
       - url: https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/refs/tags/microcode-{{ .INTEL_UCODE_VERSION }}.tar.gz
         destination: intel-ucode.tar.gz
-        sha256: fe49bb719441f20335ed6004090ab38cdc374134d36d4f5d30be7ed93b820313
-        sha512: 8316eb9d35b315e630c6c9fab1ba601b91e72cc42926ef14e7c2b77e7025d276ae06c143060f44cd1a873d3879c067d11ad82e1886c796e6be6bf466243ad85b
+        sha256: cee26f311f7e2c039dd48cd30f995183bde9b98fb4c3039800e2ddaf5c090e55
+        sha512: a684444ef81e81687ff43b8255e95675eed1d728053bb1a483a60e94e2d2d43f10fc12522510b22daf90c4debd8f035e6b9a565813aa799c2e1e3a464124f59b
     prepare:
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml

--- a/firmware/vars.yaml
+++ b/firmware/vars.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-releases extractVersion=^microcode-(?<version>.*)$ depName=intel/Intel-Linux-Processor-Microcode-Data-Files
-INTEL_UCODE_VERSION: 20230808
+INTEL_UCODE_VERSION: 20231114

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -66,6 +66,7 @@ stargz-snapshotter extension is now supported as Talos System Extension.
 * Xen Guest Utilities: 8.3.1
 * Linux Firmware: 20231030
 * gasket driver: 09385d4
+* Intel ucode: 20231114
 """
 
 


### PR DESCRIPTION
Intel released an [out-of-band µcode update](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00950.html) yesterday. This update addresses [CVE-2023-23583](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-23583), also known as [Reptar](https://lock.cmpxchg8b.com/reptar.html), a high severity at-least-DoS which can trigger machine check exceptions from ostensibly privilege separated contexts on processors where `/proc/cpuinfo` shows `flags: fsrm`.

This PR bumps the relevant values in the extensions repo. There appears to be automation here which I wasn't sure how to use, but even if this PR is deficient in some way, I hope it precipitates a new `intel-ucode` release.