### PR TITLE
fix: zfs extension

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -69,7 +69,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.7.0-alpha.0
+        defaultValue: v1.7.0-alpha.0-7-g4c59641
     depends:
       - internal/extensions/image-digests
     script:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
+# Generated on 2023-12-14T14:59:37Z by kres latest.
 
 # common variables
 
@@ -84,7 +85,7 @@ NONFREE_TARGETS = nonfree-kmod-nvidia
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.7.0-alpha.0
+PKGS ?= v1.7.0-alpha.0-7-g4c59641
 
 # help menu
 

--- a/storage/zfs/zfs-tools/pkg.yaml
+++ b/storage/zfs/zfs-tools/pkg.yaml
@@ -37,6 +37,10 @@ steps:
         rm -rf /rootfs/{etc,sbin,usr/{lib,local/share,share}}
         # remove the 69-vdev.rules, since it depends on `vdev_id` which is a shell script
         rm -f /rootfs/usr/etc/udev/rules.d/69-vdev.rules
+        # if this file is present creating a vdev tries to executes it
+        # since talos doesn't have a shell, this would fail
+        # the default shipped file is a no-op, so safe to remove.
+        rm -f /rootfs/usr/local/libexec/zfs/zfs_prepare_disk
 finalize:
   - from: /rootfs
     to: /rootfs


### PR DESCRIPTION
This fixes the zfs extension to remove the `no-op` file which depends on the host having a shell.