### PR TITLE
feat: generate a single extensions information file for all extensions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-12-12T23:07:05Z by kres latest.
+# Generated on 2023-12-19T16:28:49Z by kres latest.
 
 name: default
 concurrency:
@@ -90,6 +90,9 @@ jobs:
             })
 
             return resp.data.labels.map(label => label.name)
+      - name: check-dirty
+        run: |
+          make check-dirty
       - name: extensions
         if: github.event_name != 'pull_request'
         env:

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -50,6 +50,8 @@ spec:
 kind: auto.CustomSteps
 spec:
   steps:
+    - name: check-dirty
+      toplevel: true
     - name: extensions
       toplevel: true
     - name: extensions-metadata
@@ -57,6 +59,8 @@ spec:
     - name: internal/extensions/image-digests
       toplevel: true
     - name: sign-images
+      toplevel: true
+    - name: extensions-info
       toplevel: true
 ---
 kind: custom.Step
@@ -94,6 +98,32 @@ spec:
         @rm -f _out/extensions-metadata
         @$(foreach target,$(TARGETS),echo $(REGISTRY)/$(USERNAME)/$(target):$(shell $(ARTIFACTS)/bldr eval --target $(target) --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null) >> _out/extensions-metadata;)
         @$(foreach target,$(NONFREE_TARGETS),echo $(REGISTRY)/$(USERNAME)/$(target):$(shell $(ARTIFACTS)/bldr eval --target $(target) --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null) >> _out/extensions-metadata;)
+---
+kind: custom.Step
+name: extensions-info
+spec:
+  makefile:
+    enabled: true
+    phony: true
+    depends:
+      - $(ARTIFACTS)/bldr
+    script:
+      - |
+        @find ./ -name "manifest.yaml" -print0 | env LC_ALL=en_US sort -z | xargs -r0 -I{} sh -c 'echo "---\\n$$(cat {})"' > extensions.yaml
+---
+kind: custom.Step
+name: check-dirty
+spec:
+  makefile:
+    enabled: true
+    phony: true
+    depends:
+      - extensions-info
+    script:
+      - |
+        @if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; git diff; exit 1 ; fi
+  ghaction:
+    enabled: true
 ---
 kind: custom.Step
 name: internal/extensions/image-digests

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-12-14T14:59:37Z by kres latest.
+# Generated on 2023-12-19T15:09:45Z by kres latest.
 
 # common variables
 
@@ -163,6 +163,10 @@ $(ARTIFACTS)/bldr: $(ARTIFACTS)  ## Downloads bldr binary.
 deps.png:  ## Generates a dependency graph of the Pkgfile.
 	@$(BLDR) graph | dot -Tpng -o deps.png
 
+.PHONY: check-dirty
+check-dirty: extensions-info
+	@if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; git diff; exit 1 ; fi
+
 .PHONY: extensions
 extensions: internal/extensions/image-digests
 	@$(MAKE) docker-$@ TARGET_ARGS="--tag=$(EXTENSIONS_IMAGE_REF) --push=$(PUSH)"
@@ -184,6 +188,10 @@ sign-images:
 	  cosign verify $$image --certificate-identity-regexp '@siderolabs\.com$$' --certificate-oidc-issuer https://accounts.google.com || \
 	    cosign sign --yes $$image; \
 	done
+
+.PHONY: extensions-info
+extensions-info: $(ARTIFACTS)/bldr
+	@find ./ -name "manifest.yaml" -print0 | env LC_ALL=en_US sort -z | xargs -r0 -I{} sh -c 'echo "---\\n$$(cat {})"' > extensions.yaml
 
 .PHONY: rekres
 rekres:

--- a/extensions.yaml
+++ b/extensions.yaml
@@ -1,0 +1,370 @@
+---
+version: v1alpha1
+metadata:
+  name: ecr-credential-provider
+  version: "$VERSION"
+  author: Florian Ströger
+  description: |
+    This system extension provides a binary which implements Kubelet's CredentialProvider API
+    to authenticate against AWS' Elastic Container Registry and pull images.
+  compatibility:
+    talos:
+      version: ">= v1.6.0"
+---
+version: v1alpha1
+metadata:
+  name: gvisor
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides gVisor using containerd's runtime handler.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"
+---
+version: v1alpha1
+metadata:
+  name: stargz-snapshotter
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides Stargz Snapshotter using containerd's runtime handler.
+  compatibility:
+    talos:
+      version: ">= v1.6.0"
+---
+version: v1alpha1
+metadata:
+  name: chelsio-drivers
+  version: "$VERSION"
+  author: SideroLabs
+  description: |
+    This system extension provides Chelsio network drivers.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"
+---
+version: v1alpha1
+metadata:
+  name: gasket
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides google gasket driver kernel modules built against a specific Talos version.
+    This driver is required for PCIe and M.2 Google Coral accelerators. There are 2 kernel modules ("gasket"
+    and "apex") required to enable this driver.
+  compatibility:
+    talos:
+      version: ">= v1.2.0"
+---
+version: v1alpha1
+metadata:
+  name: mellanox-ofed
+  version: "$VERSION"
+  author: SideroLabs
+  description: |
+    This system extension provides kernel module driver for Mellanox OFED built against a specific Talos version.
+  compatibility:
+    talos:
+      version: ">= v1.3.0"
+---
+version: v1alpha1
+metadata:
+  name: thunderbolt
+  version: "$VERSION"
+  author: Igor Rzegocki
+  description: |
+    This system extension provides Thunderbolt/USB4 drivers kernel modules built against a specific Talos version.
+    This driver enables Thunderbolg/USB4 devices, including networking.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"
+---
+version: v1alpha1
+metadata:
+  name: usb-modem
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides USB modem drivers kernel modules built against a specific Talos version.
+    This driver is required for USB modems to function. This extension includes all the drivers needed to
+    operate any USB modem under Linux, but your device might not require all of them. Read your device's
+    docs to learn which drivers you need, or just enable them all as a starting point.
+  compatibility:
+    talos:
+      version: ">= v1.4.5"
+---
+version: v1alpha1
+metadata:
+  name: hello-world-service
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides an example Talos extension service.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"
+---
+version: v1alpha1
+metadata:
+  name: amd-ucode
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides AMD microcode binaries.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"
+---
+version: v1alpha1
+metadata:
+  name: amdgpu-firmware
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides AMDGPU firmware binaries.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"
+---
+version: v1alpha1
+metadata:
+  name: bnx2-bnx2x
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides bnx2 and bnx2x binaries.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"
+---
+version: v1alpha1
+metadata:
+  name: chelsio-firmware
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides Chelsio NIC firmware binaries.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"
+---
+version: v1alpha1
+metadata:
+  name: i915-ucode
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides Intel GPU microcode binaries.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"
+---
+version: v1alpha1
+metadata:
+  name: intel-ice-firmware
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides Intel Ice firmware binaries.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"
+---
+version: v1alpha1
+metadata:
+  name: intel-ucode
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides Intel microcode binaries.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"
+---
+version: v1alpha1
+metadata:
+  name: qlogic-firmware
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides firmware for QLogic devices.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"
+---
+version: v1alpha1
+metadata:
+  name: qemu-guest-agent
+  version: "$VERSION"
+  author: Markus Reiter
+  description: |
+    This system extension provides the QEMU Guest Agent service.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"
+---
+version: v1alpha1
+metadata:
+  name: xe-guest-utilities
+  version: "$VERSION"
+  author: Cas de Reuver
+  description: |
+    xe-guest-utilities communicates information and metrics with the Xen host.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"
+---
+version: v1alpha1
+metadata:
+  name: binfmt-misc
+  version: "$VERSION"
+  author: Serge Logvinov
+  description: |
+    This system extension provides kernel module driver for binfmt-misc built against a specific Talos version.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"
+---
+version: v1alpha1
+metadata:
+  name: tailscale
+  version: "$VERSION"
+  author: Beau Trepp
+  description: |
+    Tailscale connects your team's devices and development environments for easy access to remote resources.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"
+---
+version: v1alpha1
+metadata:
+  name: nonfree-kmod-nvidia
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides nvidia proprietary kernel modules built against a specific Talos version.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"
+---
+version: v1alpha1
+metadata:
+  name: nvidia-container-toolkit
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides nvidia runtime and it's dependencies using NVIDIA's runtime handler.
+  compatibility:
+    talos:
+      version: ">= v1.2.0"
+---
+version: v1alpha1
+metadata:
+  name: nvidia-fabricmanager
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides the Nvidia fabricmanager for GPU's that need NVLink support.
+  compatibility:
+    talos:
+      version: ">= v1.2.0"
+---
+version: v1alpha1
+metadata:
+  name: nvidia-open-gpu-kernel-modules
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides nvidia open source driver kernel modules built against a specific Talos version.
+  compatibility:
+    talos:
+      version: ">= v1.2.0"
+---
+version: v1alpha1
+metadata:
+  name: nut-client
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides the network-ups-tools upsmon service.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"
+---
+version: v1alpha1
+metadata:
+  name: btrfs
+  version: "$VERSION"
+  author: Enno Boland
+  description: |
+    This system extension provides kernel module driver for BTRFS built against a specific Talos version.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"
+---
+version: v1alpha1
+metadata:
+  name: drbd
+  version: "$VERSION"
+  author: Alexander Prentki
+  description: |
+    This system extension provides kernel module driver for DRBD built against a specific Talos version.
+  compatibility:
+    talos:
+      version: ">= v1.2.0"
+---
+version: v1alpha1
+metadata:
+  name: fuse3
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides fuse3 functionality.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"
+---
+version: v1alpha1
+metadata:
+  name: iscsi-tools
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides iscsi-tools.
+  compatibility:
+    talos:
+      version: ">= v1.1.0"
+---
+version: v1alpha1
+metadata:
+  name: mdadm
+  version: "$VERSION"
+  author: Serge Logvinov
+  description: |
+    This system extension provides mdadm binary.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"
+---
+version: v1alpha1
+metadata:
+  name: zfs
+  version: "$VERSION"
+  author: Andrei Kvapil, Enix
+  description: |
+    This system extension provides kernel module driver for ZFS built against a specific Talos version.
+  compatibility:
+    talos:
+      version: ">= v1.6.0"
+---
+version: v1alpha1
+metadata:
+  name: util-linux-tools
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides a minimal util-linux package.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"


### PR DESCRIPTION
Get all extensions manifests from all subfolders and put them into a single file to help with the scenario when it's necessary to read all possible extensions information.