### PR TITLE
backport: feat: generate extensions descriptions file as part of extensions image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-11-02T15:50:53Z by kres latest.
+# Generated on 2023-12-25T17:44:28Z by kres latest.
 
 _out
 internal/extensions/image-digests
+internal/extensions/descriptions.yaml

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -45,6 +45,7 @@ kind: common.Build
 spec:
     ignoredPaths:
         - "internal/extensions/image-digests"
+        - "internal/extensions/descriptions.yaml"
 ---
 kind: auto.CustomSteps
 spec:
@@ -54,6 +55,8 @@ spec:
     - name: extensions-metadata
       toplevel: true
     - name: internal/extensions/image-digests
+      toplevel: true
+    - name: internal/extensions/descriptions.yaml
       toplevel: true
     - name: sign-images
       toplevel: true
@@ -70,7 +73,7 @@ spec:
       - name: PKGS
         defaultValue: v1.6.0-9-g8fa73db
     depends:
-      - internal/extensions/image-digests
+      - internal/extensions/descriptions.yaml
     script:
       - |
         @$(MAKE) docker-$@ TARGET_ARGS="--tag=$(EXTENSIONS_IMAGE_REF) --push=$(PUSH)"
@@ -104,7 +107,24 @@ spec:
       - extensions-metadata
     script:
       - |
+        @echo "Generating image digests..."
         @cat _out/extensions-metadata | xargs -I{} sh -c 'echo {}@$$(crane digest {})' > internal/extensions/image-digests
+---
+kind: custom.Step
+name: internal/extensions/descriptions.yaml
+spec:
+  makefile:
+    enabled: true
+    phony: true
+    depends:
+      - internal/extensions/image-digests
+    script:
+      - |
+        @echo "Generating image descriptions..."
+        @echo -n "" > internal/extensions/descriptions.yaml
+        @for image in $(shell cat internal/extensions/image-digests); do \
+          crane export $$image - | tar x -O --occurrence=1 manifest.yaml | yq -r ". += {\"$$image\": {\"author\": .metadata.author, \"description\": .metadata.description}} | del(.metadata, .version)" - >> internal/extensions/descriptions.yaml; \
+        done
 ---
 kind: custom.Step
 name: sign-images

--- a/internal/extensions/pkg.yaml
+++ b/internal/extensions/pkg.yaml
@@ -4,3 +4,5 @@ variant: scratch
 finalize:
   - from: /pkg/image-digests
     to: /image-digests
+  - from: /pkg/descriptions.yaml
+    to: /descriptions.yaml


### PR DESCRIPTION
Add all authors and descriptions to the `descriptions.yaml` file, then add this file to the published `extensions` docker image.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>
(cherry picked from commit 57503ccd3bbba510401dbde67340b71eee0adfee)