### PR TITLE
fix: qemu-guest-agent not starting in maintenance mode.

### DIFF
--- a/guest-agents/qemu-guest-agent/qemu-guest-agent.yaml
+++ b/guest-agents/qemu-guest-agent/qemu-guest-agent.yaml
@@ -1,6 +1,5 @@
 name: qemu-guest-agent
 depends:
-  - service: cri
   - path: /system/run/machined/machine.sock
   - path: /dev/virtio-ports/org.qemu.guest_agent.0
 container:
@@ -20,7 +19,7 @@ container:
         - bind
         - ro
     # State files.
-    - source: /var/run
+    - source: /system/run/qemu-guest-agent
       destination: /var/run
       type: bind
       options:


### PR DESCRIPTION
Allows qemu-ga to run under maintenance mode.

Resolves: #293