### PR TITLE
feat: add applesmc-t2 to support fan control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ COMMON_ARGS += --build-arg=PKGS="$(PKGS)"
 
 TARGETS = amdgpu-firmware
 TARGETS += amd-ucode
+TARGETS += applesmc-t2
 TARGETS += binfmt-misc
 TARGETS += bnx2-bnx2x
 TARGETS += btrfs

--- a/drivers/applesmc-t2/README.md
+++ b/drivers/applesmc-t2/README.md
@@ -1,0 +1,18 @@
+# applesmc-t2 extension
+
+## Installation
+
+See [Installing Extensions](https://github.com/siderolabs/extensions#installing-extensions).
+
+## Usage
+
+Provides:
+
+* `applesmc`
+
+```yaml
+machine:
+  kernel:
+    modules:
+      - name: applesmc
+```

--- a/drivers/applesmc-t2/manifest.yaml
+++ b/drivers/applesmc-t2/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: applesmc-t2
+  version: "$VERSION"
+  author: Anthony A.
+  description: |
+    applesmc module patched for t2 chips to allow fan control with t2fand
+  compatibility:
+    talos:
+      version: ">= v1.5.0"

--- a/drivers/applesmc-t2/pkg.yaml
+++ b/drivers/applesmc-t2/pkg.yaml
@@ -1,0 +1,23 @@
+name: applesmc-t2
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  # The pkgs version for a particular release of Talos as defined in
+  # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
+  - image: "{{ .PKGS_PREFIX }}/applesmc-t2-pkg:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - prepare:
+      - |
+        export KERNELRELEASE=$(find /lib/modules -type d -name "*-talos" -exec basename {} \+)
+        sed -i "s#\$VERSION#${KERNELRELEASE}-{{ .VERSION }}#" /pkg/manifest.yaml
+  - install:
+      - |
+        mkdir -p /rootfs/lib/modules
+
+        cp -R /lib/modules/* /rootfs/lib/modules
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/drivers/applesmc-t2/vars.yaml
+++ b/drivers/applesmc-t2/vars.yaml
@@ -1,0 +1,1 @@
+VERSION: "{{ .BUILD_ARG_TAG }}"


### PR DESCRIPTION
Avoid over heating by allowing fan control on mac mini 2018 late