### PR TITLE
fix: set `DATABASE_PATH` for fabricmanager

### DIFF
--- a/nvidia-gpu/nvidia-fabricmanager/pkg.yaml
+++ b/nvidia-gpu/nvidia-fabricmanager/pkg.yaml
@@ -43,6 +43,7 @@ steps:
         sed -i 's/DAEMONIZE=.*/DAEMONIZE=0/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
         sed -i 's/STATE_FILE_NAME=.*/STATE_FILE_NAME=\/var\/run\/nvidia-fabricmanager\/fabricmanager.state/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
         sed -i 's/TOPOLOGY_FILE_PATH=.*/TOPOLOGY_FILE_PATH=\/usr\/local\/share\/nvidia\/nvswitch/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
+        sed -i 's/DATABASE_PATH=.*/DATABASE_PATH=\/usr\/local\/share\/nvidia\/nvswitch/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
 finalize:
   - from: /rootfs
     to: /rootfs


### PR DESCRIPTION
This fixes fabricmanager crashing.

Signed-off-by: Noel Georgi <git@frezbo.dev>
(cherry picked from commit 799a3403eab2e28baed1e44063c1851d72215eee)