### PR TITLE
fix: set `DATABASE_PATH` for fabricmanager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 
 # keep in sync with Pkgfile
 BLDR_RELEASE ?= v0.2.0
-PKGS ?= v1.5.0-15-gab5b0e5
+PKGS ?= v1.5.0-17-ga550ab9
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64,linux/arm64

--- a/nvidia-gpu/nvidia-fabricmanager/pkg.yaml
+++ b/nvidia-gpu/nvidia-fabricmanager/pkg.yaml
@@ -43,6 +43,7 @@ steps:
         sed -i 's/DAEMONIZE=.*/DAEMONIZE=0/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
         sed -i 's/STATE_FILE_NAME=.*/STATE_FILE_NAME=\/var\/run\/nvidia-fabricmanager\/fabricmanager.state/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
         sed -i 's/TOPOLOGY_FILE_PATH=.*/TOPOLOGY_FILE_PATH=\/usr\/local\/share\/nvidia\/nvswitch/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
+        sed -i 's/DATABASE_PATH=.*/DATABASE_PATH=\/usr\/local\/share\/nvidia\/nvswitch/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
 finalize:
   - from: /rootfs
     to: /rootfs

--- a/nvidia-gpu/vars.yaml
+++ b/nvidia-gpu/vars.yaml
@@ -8,7 +8,7 @@ CONTAINER_TOOLKIT_REF: 6b8589dcb4dead72ab64f14a5912886e6165c079
 LIBNVIDIA_CONTAINER_VERSION: v1.13.5
 LIBNVIDIA_CONTAINER_REF: 66607bd046341f7aad7de80a9f022f122d1f2fce
 # renovate: datasource=docker versioning=docker depName=cgr.dev/chainguard/wolfi-base
-WOLFI_BASE_VERSION: latest@sha256:255b803e19a867695128b838d54f115cbd0dfaa34d78a5119a4c23212814ae95 # latest-20230621 has a bug with buildng apps
+WOLFI_BASE_VERSION: latest@sha256:91f3e08712a854ff4a146b7cca7f1b7581f205bc589a06135f51590e00d2990e
 # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
 GLIBC_VERSION: 2.38
 # renovate: datasource=git-tags extractVersion=^libtiprc-(?<version>.*)$ depName=git://linux-nfs.org/~steved/libtirpc


### PR DESCRIPTION
This fixes fabricmanager crashing.

Signed-off-by: Noel Georgi <git@frezbo.dev>
(cherry picked from commit 799a3403eab2e28baed1e44063c1851d72215eee)