### PR TITLE
chore: bump dependencies

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -81,7 +81,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.7.0-alpha.0-19-g96cc841
+        defaultValue: v1.7.0-alpha.0-29-g1904994
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
     depends:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-15T18:32:58Z by kres latest.
+# Generated on 2024-02-20T14:43:02Z by kres latest.
 
 # common variables
 
@@ -88,7 +88,7 @@ NONFREE_TARGETS = nonfree-kmod-nvidia
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.7.0-alpha.0-19-g96cc841
+PKGS ?= v1.7.0-alpha.0-29-g1904994
 PKGS_PREFIX ?= ghcr.io/siderolabs
 
 # help menu

--- a/Pkgfile
+++ b/Pkgfile
@@ -11,7 +11,7 @@ vars:
   # renovate: datasource=git-tags extractVersion=^libtiprc-(?<version>.*)$ depName=git://linux-nfs.org/~steved/libtirpc
   LIBTIRPC_VERSION: 1-3-3
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=madler/zlib
-  ZLIB_VERSION: 1.2.13
+  ZLIB_VERSION: 1.3.1
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/extensions

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21
+go 1.22
 
 use (
 	./examples/hello-world-service/src

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,4 +1,4 @@
+golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=

--- a/guest-agents/qemu-guest-agent/glib/pkg.yaml
+++ b/guest-agents/qemu-guest-agent/glib/pkg.yaml
@@ -9,8 +9,8 @@ steps:
   - sources:
       - url: https://download.gnome.org/sources/glib/{{ regexReplaceAll ".\\d+$" .GLIB_VERSION "${1}" }}/glib-{{ .GLIB_VERSION }}.tar.xz
         destination: glib.tar.xz
-        sha256: 915bc3d0f8507d650ead3832e2f8fb670fce59aac4d7754a7dab6f1e6fed78b2
-        sha512: aa9ed9195951b00ac8221e958ea337fbda82621a862ef8f29dc2ea396a6253ce51c2a0a498dfa4e12642f1836f85f9564f09991979ae85c5ed4368355d857376
+        sha256: a47f7ecf7bba0346e6cd562887b93ee4ee37a57d8dcae0755f0de8dc75ca5e8c
+        sha512: c4cf99546828d8b8310faafcafef6db17381d07973d465e7699a2b8743687c730496de38c5ab670613411b89358f6cd60cc9aad2f35bf0a80d12a53d79f15581
     prepare:
       - |
         tar -xf glib.tar.xz --strip-components=1
@@ -21,7 +21,7 @@ steps:
         ln -s /toolchain/bin/env /usr/bin/env
         ln -s /toolchain/bin/python3 /toolchain/bin/python
 
-        pip3 install ninja
+        pip3 install ninja packaging
     build:
       - |
         export PKG_CONFIG_PATH=/usr/lib/pkgconfig

--- a/guest-agents/qemu-guest-agent/pkg.yaml
+++ b/guest-agents/qemu-guest-agent/pkg.yaml
@@ -10,8 +10,8 @@ steps:
   - sources:
       - url: https://download.qemu.org/qemu-{{ .QEMU_VERSION }}.tar.xz
         destination: qemu.tar.xz
-        sha256: bf00d2fa12010df8b0ade93371def58e632cb32a6bfdc5f5a0ff8e6a1fb1bf32
-        sha512: 92ec41196ff145cdbb98948f6b6e43214fa4b4419554a8a1927fb4527080c8212ccb703e184baf8ee0bdfa50ad7a84689e8f5a69eba1bd7bbbdfd69e3b91256c
+        sha256: 8562751158175f9d187c5f22b57555abe3c870f0325c8ced12c34c6d987729be
+        sha512: e72d3e13339c03e8d371ca060ac700c45af2ca37523cddb6b02dcaf8430d75c8cef194cf496df9816440b281f368457def1126677db757928805d93ceca2f9af
     prepare:
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml

--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -1,8 +1,8 @@
 # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=https://github.com/qemu/qemu.git
-QEMU_VERSION: 8.2.0
+QEMU_VERSION: 8.2.1
 # renovate: datasource=git-tags depName=https://gitlab.gnome.org/GNOME/glib.git
-GLIB_VERSION: 2.78.1
+GLIB_VERSION: 2.79.2
 # renovate: datasource=github-releases extractVersion=^pcre2-(?<version>.*)$ depName=PCRE2Project/pcre2
 PCRE2_VERSION: 10.42
 # renovate: datasource=github-releases extractVersion=^v(?<version>.*)$ depName=xenserver/xe-guest-utilities
-XE_GUEST_UTILITIES_VERSION: 8.3.1
+XE_GUEST_UTILITIES_VERSION: 8.4.0

--- a/guest-agents/xe-guest-utilities/pkg.yaml
+++ b/guest-agents/xe-guest-utilities/pkg.yaml
@@ -8,8 +8,8 @@ steps:
       GOPATH: /go
   - sources:
       - url: https://github.com/xenserver/xe-guest-utilities/archive/refs/tags/v{{ .XE_GUEST_UTILITIES_VERSION }}.tar.gz
-        sha256: 8c4f9b7d6492bb01b7629c67ae04b745acaf81d8afb0af96da484bb791d1c35c
-        sha512: 3db437c10dec61ff3620c8ce92eecc5239f8d5136f67bdac73f6e41001b3a45675258f02d8c8b06361891240a91790c7e3a9ba27cd8cf79a7aa70df7c5b2e404
+        sha256: b800a499df21b9993e0ceb36bce18046b3d4622df85693a8b5b40dcf21a78b4f
+        sha512: 1ecf9079537864e06ab9ef622f8fc17f12252d14a2003b757d8709f8409e59709f44243f79a5dd0e5715b94f58e6953c65fcf46da302f95abb91d18d86831dc8
         destination: xe-guest-utilities.tar.gz
     prepare:
       - |

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -23,8 +23,11 @@ See [Talos Linux documentation](https://www.talos.dev/v1.7/talos-guides/configur
 * Linux Firmware: 20240115
 * DRBD: 9.2.7
 * gvisor: 20240109.0
-* QEMU: 8.2.0
-* Tailscale: 1.56.1
+* QEMU: 8.2.1
+* Tailscale: 1.60.0
+* nvidia-container-runtime: v1.14.5
+* libnvidia-container: v1.14.5
+* xe-guest-utilities: 8.4.0
 """
 
 

--- a/network/tailscale/pkg.yaml
+++ b/network/tailscale/pkg.yaml
@@ -9,8 +9,8 @@ steps:
   - sources:
       - url: https://github.com/tailscale/tailscale/archive/refs/tags/v{{ .TAILSCALE_VERSION }}.tar.gz
         destination: tailscale.tar.gz
-        sha256: 56b7d25c704e3c22e9e20dcb55695cd9c816878d2c172a73c64aac42e460fd41
-        sha512: a6e213eeb885d160b816f7d795d8ae66cd322d652657ee5309e220c6526eb73d5aea07dcd57983468520891c5405fcb84255350cdacc078514cede8a351a4888
+        sha256: b857ba9944e37332c245bc9ebc158150b2e785909f27d32b6f7e01557150e88a
+        sha512: 81c96c6f64d4141894673be7d524bacae7485f9c1d63fde5dcea952573daafc87c9f5b5fa17ceabe8e88a4d61b4f939822228fb2a310bd8522ca15f7cb9c3a60
     prepare:
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml

--- a/network/vars.yaml
+++ b/network/vars.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-releases extractVersion=^v(?<version>.*)$ depName=tailscale/tailscale
-TAILSCALE_VERSION: 1.56.1
+TAILSCALE_VERSION: 1.60.0

--- a/nvidia-gpu/nvidia-container-toolkit/glibc/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/glibc/pkg.yaml
@@ -13,8 +13,8 @@ steps:
   - sources:
       - url: https://ftpmirror.gnu.org/libc/glibc-{{ .GLIBC_VERSION }}.tar.gz
         destination: glibc.tar.gz
-        sha256: 16e51e0455e288f03380b436e41d5927c60945abd86d0c9852b84be57dd6ed5e
-        sha512: ca799ef40129433791777c698b62142edf0f0e8a87552f324ee6a036a2fe747b867696863692bde45bdd4a263ac6c419a52f92c1b6072b8ff49a887ebaa45299
+        sha256: 97f84f3b7588cd54093a6f6389b0c1a81e70d99708d74963a2e3eab7c7dc942d
+        sha512: ba07187610f660236ba4fbff06420f01ce5aa0138c9b5f0ee7ad6a8c2a178bf899a65a097a769d890813e50942c0c9f793ca8a63a2d13bfcef6e21a12486af3a
     prepare:
       - |
         tar -xzf glibc.tar.gz --strip-components=1

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libseccomp/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libseccomp/pkg.yaml
@@ -11,8 +11,8 @@ steps:
   - sources:
       - url: https://github.com/seccomp/libseccomp/releases/download/v{{ .LIBSECCOMP_VERSION }}/libseccomp-{{ .LIBSECCOMP_VERSION }}.tar.gz
         destination: libseccomp.tar.gz
-        sha256: d82902400405cf0068574ef3dc1fe5f5926207543ba1ae6f8e7a1576351dcbdb
-        sha512: 92650bd7d1d48b383f402a536b97a017fd0f6ad1234daf4b938d01c92e8d134a01d2f2dd45fd9e2d025d7556bd1386ec360402145a87f20580c85949d62cea0e
+        sha256: 248a2c8a4d9b9858aa6baf52712c34afefcf9c9e94b76dce02c1c9aa25fb3375
+        sha512: f630e7a7e53a21b7ccb4d3e7b37616b89aeceba916677c8e3032830411d77a14c2d74dcf594cd193b1acc11f52595072e28316dc44300e54083d5d7b314a38da
     prepare:
       - |
         tar -xzf libseccomp.tar.gz --strip-components=1

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/pkg.yaml
@@ -4,7 +4,7 @@ shell: /bin/bash
 install:
   - build-base
   - bash
-  - go
+  - go~1.20 # ref: https://github.com/NVIDIA/nvidia-container-toolkit/issues/372
   - coreutils
   - sed
   - curl
@@ -30,11 +30,12 @@ steps:
   - sources:
       - url: https://gitlab.com/nvidia/container-toolkit/libnvidia-container/-/archive/{{ .LIBNVIDIA_CONTAINER_VERSION }}/libnvidia-container-{{ .LIBNVIDIA_CONTAINER_VERSION }}.tar.gz
         destination: libnvidia-container.tar.gz
-        sha256: 4beebedd045468e8174895f5d4a563f7880cf7a10f062d996719c061fcdaa0db
-        sha512: a16f163cb8689f4b6279bed1a5965ee4c56f413918cae6acf272ca5adf7dd929818d977dd6657ce496abeb842b56e03bfd83bda828a7b953625b2999ac174b93
+        sha256: d8980359437c7b9f1835ef3741609b4e688347f72c2213cdb522def0daf4a29c
+        sha512: 803c5e9941bf4def21ab4cf631aee90ceaa06bf23f4a735b174ce3272140fdabd037c5e0267d71c79fd506ffded182ed43dd07e30bda2636d72f9f67c2ea5621
     env:
       SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
       REVISION: {{ .LIBNVIDIA_CONTAINER_REF }}
+      LIB_VERSION: {{ .LIBNVIDIA_CONTAINER_VERSION | replace "v" "" }}
       WITH_NVCGO: yes
       WITH_LIBELF: yes
       WITH_TIRPC: no # setting no means we'll use the system libtirpc

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/zlib/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/zlib/pkg.yaml
@@ -10,8 +10,8 @@ steps:
   - sources:
       - url: https://zlib.net/fossils/zlib-{{ .ZLIB_VERSION }}.tar.gz
         destination: zlib.tar.gz
-        sha256: b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
-        sha512: 99f0e843f52290e6950cc328820c0f322a4d934a504f66c7caa76bd0cc17ece4bf0546424fc95135de85a2656fed5115abb835fd8d8a390d60ffaf946c8887ad
+        sha256: 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+        sha512: 580677aad97093829090d4b605ac81c50327e74a6c2de0b85dd2e8525553f3ddde17556ea46f8f007f89e435493c9a20bc997d1ef1c1c2c23274528e3c46b94f
     prepare:
       - |
         tar -xf zlib.tar.gz --strip-components=1

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.mod
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.mod
@@ -1,5 +1,5 @@
 module nvidia-container-runtime-wrapper
 
-go 1.21
+go 1.22
 
-require golang.org/x/sys v0.15.0
+require golang.org/x/sys v0.17.0

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.sum
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/pkg.yaml
@@ -4,7 +4,7 @@ shell: /bin/bash
 install:
   - build-base
   - bash
-  - go
+  - go~1.20 # ref: https://github.com/NVIDIA/nvidia-container-toolkit/issues/372
   - patch
 dependencies:
   - image: cgr.dev/chainguard/wolfi-base@{{ .WOLFI_BASE_REF }}
@@ -12,8 +12,8 @@ steps:
   - sources:
       - url: https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/archive/{{ .CONTAINER_TOOLKIT_VERSION }}/container-toolkit-{{ .CONTAINER_TOOLKIT_VERSION }}.tar.gz
         destination: container-toolkit.tar.gz
-        sha256: b9ee6f96addbcbace9503f29551b4f3c42d76293a0d54f5c6009971909dac0fc
-        sha512: 69bfac15d8be2797b09dda35650a90dcb2c24ca7a5107c3df5946840a55df8dc62cb5cc46f172169ee3e8447c416733848b513b92dc512df35e0aad7c77e5c1e
+        sha256: 5b1cadea5a79cde2049def4f01dc1ee6c26142391aede9056d69cfeee04d84dd
+        sha512: dc2ffc4f6d93b94c872c00a3f670952974205fc71030cd838859e5c3201f2900c19a23ab128784b9d945c59efd69792e9a54ce5658e2c8946c9ccf7e74e41453
     env:
       GIT_COMMIT: {{ substr 0 7 .CONTAINER_TOOLKIT_REF }} # build is using short sha
     prepare:

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
@@ -1,5 +1,5 @@
 module nvidia-persistenced-wrapper
 
-go 1.21
+go 1.22
 
-require golang.org/x/sys v0.15.0
+require golang.org/x/sys v0.17.0

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/nvidia-gpu/vars.yaml
+++ b/nvidia-gpu/vars.yaml
@@ -2,17 +2,17 @@
 # renovate: datasource=github-releases depName=nvidia/open-gpu-kernel-modules
 NVIDIA_DRIVER_VERSION: 535.129.03
 # renovate: datasource=git-tags depName=https://gitlab.com/nvidia/container-toolkit/container-toolkit.git
-CONTAINER_TOOLKIT_VERSION: v1.13.5
-CONTAINER_TOOLKIT_REF: 6b8589dcb4dead72ab64f14a5912886e6165c079
+CONTAINER_TOOLKIT_VERSION: v1.14.5
+CONTAINER_TOOLKIT_REF: 9ea336070134e612145d342e495f2fc616aab063
 # renovate: datasource=git-tags depName=https://gitlab.com/nvidia/container-toolkit/libnvidia-container.git
-LIBNVIDIA_CONTAINER_VERSION: v1.13.5
-LIBNVIDIA_CONTAINER_REF: 66607bd046341f7aad7de80a9f022f122d1f2fce
+LIBNVIDIA_CONTAINER_VERSION: v1.14.5
+LIBNVIDIA_CONTAINER_REF: 870d7c5d957f5780b8afa57c4d5cc924d4d9ed26
 # renovate: datasource=docker versioning=docker depName=cgr.dev/chainguard/wolfi-base
-WOLFI_BASE_REF: sha256:91f3e08712a854ff4a146b7cca7f1b7581f205bc589a06135f51590e00d2990e
-# renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-GLIBC_VERSION: 2.38
+WOLFI_BASE_REF: sha256:09087ed84e6040a4f82530531171005212331f391b4e625275809346afd8d03b
+# renovate: datasource=git-tags extractVersion=^glibc-(?<version>.*)$ depName=https://sourceware.org/git/glibc.git
+GLIBC_VERSION: 2.39
 # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=seccomp/libseccomp
-LIBSECCOMP_VERSION: 2.5.4
+LIBSECCOMP_VERSION: 2.5.5
 # renovate: datasource=git-tags extractVersion=^libcap-(?<version>.*)$ depName=git://git.kernel.org/pub/scm/libs/libcap/libcap.git
 LIBCAP_VERSION: 2.69
 # renovate: datasource=git-tags extractVersion=^elfutils-(?<version>.*)$ depName=git://sourceware.org/git/elfutils.git

--- a/storage/iscsi-tools/iscsid-wrapper/go.mod
+++ b/storage/iscsi-tools/iscsid-wrapper/go.mod
@@ -1,5 +1,5 @@
 module iscsid-wrapper
 
-go 1.21
+go 1.22
 
-require golang.org/x/sys v0.15.0
+require golang.org/x/sys v0.17.0

--- a/storage/iscsi-tools/iscsid-wrapper/go.sum
+++ b/storage/iscsi-tools/iscsid-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
Bump dependencies.

Use [go1.20 for building nvidia stuff](https://github.com/NVIDIA/nvidia-container-toolkit/issues/372).