### PR TITLE
feat: add mdmon to mdadm extension

### DIFF
--- a/storage/mdadm/pkg.yaml
+++ b/storage/mdadm/pkg.yaml
@@ -26,10 +26,12 @@ steps:
 
         CXFLAGS=-D_LARGEFILE64_SOURCE \
         make -j $(nproc) mdadm
+        make -j $(nproc) mdmon
     install:
       - |
         mkdir -p /rootfs/usr/local/sbin /rootfs/usr/etc/udev/rules.d
         cp mdadm /rootfs/usr/local/sbin/mdadm
+        cp mdmon /rootfs/usr/local/sbin/mdmon
         cp /pkg/files/udev-md-raid-arrays.rules   /rootfs/usr/etc/udev/rules.d/63-md-raid-arrays.rules
         cp /pkg/files/udev-md-raid-assembly.rules /rootfs/usr/etc/udev/rules.d/64-md-raid-assembly.rules
 finalize:


### PR DESCRIPTION
In Intel VROC setups, maintaining the integrity of imsm metadata is essential. mdmon plays a pivotal role in ensuring the efficiency of metadata management. Our PR incorporates mdmon into the directory alongside mdadm. This integration guarantees proper functionality in Intel VROC environments