### PR TITLE
chore: drop Drone requests for resources

### DIFF
--- a/.drone.yaml
+++ b/.drone.yaml
@@ -14,10 +14,6 @@ steps:
       SSH_KEY:
         from_secret: ssh_key
       DOCKER_CLI_EXPERIMENTAL: enabled
-    resources:
-      requests:
-        cpu: 24000
-        memory: 48GiB
     volumes:
       - name: outer-docker-socket
         path: /var/run


### PR DESCRIPTION
We only build for Talos integration tests, and resource allocation works very bad when promoted from a Talos pipeline.