### PR TITLE
fix: vmtoolsd extension name

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -31,11 +31,11 @@ spec:
     - realtek-firmware
     - stargz-snapshotter
     - tailscale
-    - talos-vmtoolsd
     - thunderbolt
     - usb-modem-drivers
     - util-linux-tools
     - v4l-uvc-drivers
+    - vmtoolsd-guest-agent
     - wasmedge
     - xen-guest-agent
     - zfs

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-04-02T12:54:22Z by kres latest.
+# Generated on 2024-04-03T11:18:15Z by kres latest.
 
 # common variables
 
@@ -85,11 +85,11 @@ TARGETS += qlogic-firmware
 TARGETS += realtek-firmware
 TARGETS += stargz-snapshotter
 TARGETS += tailscale
-TARGETS += talos-vmtoolsd
 TARGETS += thunderbolt
 TARGETS += usb-modem-drivers
 TARGETS += util-linux-tools
 TARGETS += v4l-uvc-drivers
+TARGETS += vmtoolsd-guest-agent
 TARGETS += wasmedge
 TARGETS += xen-guest-agent
 TARGETS += zfs

--- a/guest-agents/talos-vmtoolsd/pkg.yaml
+++ b/guest-agents/talos-vmtoolsd/pkg.yaml
@@ -1,4 +1,4 @@
-name: talos-vmtoolsd
+name: vmtoolsd-guest-agent
 variant: scratch
 dependencies:
   - image: {{ .BUILD_ARG_PKGS_PREFIX }}/talos-vmtoolsd:{{ .TALOS_VMTOOLSD_VERSION }}

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -23,17 +23,24 @@ Xen guest agent extension is now available. This removes the previous `xe-guest-
 See [this](https://github.com/xenserver/xe-guest-utilities/issues/118) for more info.
 """
 
+    [notes.vmtoolsd]
+        title = "VMware Tools Daemon"
+        description = """\
+VMware Tools Daemon extension is now available. This extension provides the VMware Tools Daemon for VMware guests.
+See [Talos VMToolsd](https://github.com/siderolabs/talos-vmtoolsd/) for more info.
+"""
+
     [notes.updates]
         title = "Component Updates"
         description = """\
 * ZFS: 2.2.3
 * Linux Firmware: 20240312
 * DRBD: 9.2.8
-* gvisor: 20240305.0
+* gvisor: 20240325.0
 * QEMU: 8.2.2
-* Tailscale: 1.60.1
-* nvidia-container-runtime: v1.14.5
-* libnvidia-container: v1.14.5
+* Tailscale: 1.62.1
+* nvidia-container-runtime: v1.14.6
+* libnvidia-container: v1.14.6
 * Intel CPU Microcode: 20240312
 """
 


### PR DESCRIPTION
Fix the name used for vmtools, as it was conflicting with the container image name in talos-vmtoolds repo.