### PR TITLE
fix: version in util-linux manifest

### DIFF
--- a/tools/util-linux/pkg.yaml
+++ b/tools/util-linux/pkg.yaml
@@ -27,6 +27,8 @@ steps:
             --enable-libmount \
             --enable-libblkid \
             --enable-fstrim \
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
     build:
       - |
         cd build


### PR DESCRIPTION
It always showed `$VERSION` as the installed version.