### PR TITLE
fix: rekres the repo after pkgs bump

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-04-02T10:25:42Z by kres latest.
+# Generated on 2024-05-02T15:06:54Z by kres d15226e.
 
 name: default
 concurrency:
@@ -47,6 +47,7 @@ jobs:
         run: |
           git fetch --prune --unshallow
       - name: Set up Docker Buildx
+        id: setup-buildx
         uses: docker/setup-buildx-action@v3
         with:
           append: |
@@ -129,6 +130,7 @@ jobs:
         run: |
           git fetch --prune --unshallow
       - name: Set up Docker Buildx
+        id: setup-buildx
         uses: docker/setup-buildx-action@v3
         with:
           append: |

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-04-02T10:25:42Z by kres latest.
+# Generated on 2024-05-02T15:06:54Z by kres d15226e.
 
 name: weekly
 concurrency:
@@ -30,6 +30,7 @@ jobs:
         run: |
           git fetch --prune --unshallow
       - name: Set up Docker Buildx
+        id: setup-buildx
         uses: docker/setup-buildx-action@v3
         with:
           append: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-04-18T15:21:55Z by kres 92eef68.
+# Generated on 2024-05-02T15:06:54Z by kres d15226e.
 
 # common variables
 
@@ -52,7 +52,7 @@ COMMON_ARGS += --build-arg=PKGS_PREFIX="$(PKGS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.8.0-alpha.0-5-gdfa7dce
+PKGS ?= v1.8.0-alpha.0-10-g28c5696
 PKGS_PREFIX ?= ghcr.io/siderolabs
 
 # targets defines all the available targets


### PR DESCRIPTION
I forgot to do that, and 1.8.0-alpha.0 release is now out of sync with Talos.

I will re-do the release.