### PR TITLE
fix: extension name in manifests

### DIFF
--- a/drivers/gasket/manifest.yaml
+++ b/drivers/gasket/manifest.yaml
@@ -1,6 +1,6 @@
 version: v1alpha1
 metadata:
-  name: gasket
+  name: gasket-driver
   version: "$VERSION"
   author: Sidero Labs
   description: |

--- a/drivers/usb-modem/manifest.yaml
+++ b/drivers/usb-modem/manifest.yaml
@@ -1,6 +1,6 @@
 version: v1alpha1
 metadata:
-  name: usb-modem
+  name: usb-modem-drivers
   version: "$VERSION"
   author: Sidero Labs
   description: |

--- a/drivers/v4l-uvc/manifest.yaml
+++ b/drivers/v4l-uvc/manifest.yaml
@@ -1,6 +1,6 @@
 version: v1alpha1
 metadata:
-  name: v4l-uvc
+  name: v4l-uvc-drivers
   version: "$VERSION"
   author: Jacob McSwain
   description: |


### PR DESCRIPTION
Extension name in the manifest should match the published name.

Also there's a problem with `talos-vmtoolsd`, but it should be fixed in its repository.