### PR TITLE
feat: include `nsenter` when building util-linux binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ cosign verify --certificate-identity-regexp '@siderolabs\.com$' --certificate-oi
 
 #### Tools
 
-| Name                                  | Description                        | Version Format     |
-| ------------------------------------- | ---------------------------------- | ------------------ |
-| [util-linux-tools](tools/util-linux/) | Util Linux tools (only fstrim now) | `upstream version` |
+| Name                                  | Description                               | Version Format     |
+| ------------------------------------- | ----------------------------------------- | ------------------ |
+| [util-linux-tools](tools/util-linux/) | Util Linux tools (`fstrim` and `nsenter`) | `upstream version` |
 
 ## Building Extensions
 

--- a/tools/util-linux/pkg.yaml
+++ b/tools/util-linux/pkg.yaml
@@ -26,6 +26,7 @@ steps:
             --disable-all-programs \
             --enable-libmount \
             --enable-libblkid \
+            --enable-nsenter \
             --enable-fstrim \
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml


### PR DESCRIPTION
PR just includes `nsenter` in the subset of built binaries when compiling `util-linux`. Specifically, having `nsenter` allows several common tools written in golang to run on Talos.