### PR TITLE
fix: gvisor-debug extension

### DIFF
--- a/container-runtime/gvisor-debug/pkg.yaml
+++ b/container-runtime/gvisor-debug/pkg.yaml
@@ -21,3 +21,5 @@ steps:
 finalize:
   - from: /pkg/manifest.yaml
     to: /
+  - from: /rootfs
+    to: /rootfs


### PR DESCRIPTION
Fix gvisor-debug extension, got broken when adding extensions-validator.