### PR TITLE
fix: zfs-tools libtirpc path

### DIFF
--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/elfutils/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/elfutils/pkg.yaml
@@ -11,7 +11,7 @@ dependencies:
     from: /rootfs
 steps:
   - sources:
-      - url: https://sourceware.org/elfutils/ftp/{{ .ELFUTILS_VERSION }}/elfutils-{{ .ELFUTILS_VERSION }}.tar.bz2
+      - url: https://src.fedoraproject.org/lookaside/extras/elfutils/elfutils-{{ .ELFUTILS_VERSION }}.tar.bz2/sha512/e22d85f25317a79b36d370347e50284c9120c86f9830f08791b7b6a7b4ad89b9bf4c7c71129133b8d193a0edffb2a2c17987b7e48428b9670aff5ce918777e04/elfutils-{{ .ELFUTILS_VERSION }}.tar.bz2
         destination: elfutils.tar.bz2
         sha256: df76db71366d1d708365fc7a6c60ca48398f14367eb2b8954efc8897147ad871
         sha512: e22d85f25317a79b36d370347e50284c9120c86f9830f08791b7b6a7b4ad89b9bf4c7c71129133b8d193a0edffb2a2c17987b7e48428b9670aff5ce918777e04

--- a/storage/zfs/zfs-tools/libtirpc/pkg.yaml
+++ b/storage/zfs/zfs-tools/libtirpc/pkg.yaml
@@ -26,7 +26,7 @@ steps:
         export CFLAGS="${CFLAGS} -I/usr/local/include"
 
         ./configure \
-          --prefix=/usr/local \
+          --prefix=/usr/local/libtirpc \
           --disable-gssapi
     build:
       - |

--- a/storage/zfs/zfs-tools/pkg.yaml
+++ b/storage/zfs/zfs-tools/pkg.yaml
@@ -20,6 +20,8 @@ steps:
         tar -xf zfs.tar.gz --strip-components=1
     build:
       - |
+        export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/local/libtirpc/lib/pkgconfig
+
         ./configure \
           --prefix=/usr/local \
           --with-udevdir=/usr/local/sbin \


### PR DESCRIPTION
Use a custom path for libtirpc shipped with zfs-tools so that it doesn't conflict with libtirpc built for nvidia-container-toolkit (as it's linked against glibc).

Fixes: #380