### PR TITLE
fix: zfs extensions with nvidia

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -53,7 +53,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.8.0-alpha.0-19-gf350879
+        defaultValue: v1.8.0-alpha.0-23-gc309452
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
   useBldrPkgTagResolver: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-23T15:58:32Z by kres 2688b70.
+# Generated on 2024-06-12T05:27:15Z by kres 7360563.
 
 # common variables
 
@@ -25,7 +25,7 @@ SOURCE_DATE_EPOCH := $(shell git log $(INITIAL_COMMIT_SHA) --pretty=%ct)
 
 # sync bldr image with pkgfile
 
-BLDR_RELEASE := v0.3.0
+BLDR_RELEASE := v0.3.1
 BLDR_IMAGE := ghcr.io/siderolabs/bldr:$(BLDR_RELEASE)
 BLDR := docker run --rm --user $(shell id -u):$(shell id -g) --volume $(PWD):/src --entrypoint=/bldr $(BLDR_IMAGE) --root=/src
 
@@ -48,7 +48,7 @@ COMMON_ARGS += --build-arg=PKGS_PREFIX="$(PKGS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.8.0-alpha.0-19-gf350879
+PKGS ?= v1.8.0-alpha.0-23-gc309452
 PKGS_PREFIX ?= ghcr.io/siderolabs
 
 # targets defines all the available targets

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/elfutils/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/elfutils/pkg.yaml
@@ -22,8 +22,10 @@ steps:
         mkdir build
         cd build
 
+        export CFLAGS="${CFLAGS} -I/usr/local/glibc/include/ -L/usr/local/glibc/lib"
+
         ../configure \
-            --prefix=/usr/local \
+            --prefix=/usr/local/glibc \
             --with-zstd=no \
             --disable-libdebuginfod \
             --disable-debuginfod \

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libcap2/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libcap2/pkg.yaml
@@ -17,7 +17,7 @@ steps:
         tar -xf libcap.tar.xz --strip-components=1
     build:
       - |
-        make prefix=/usr/local lib=lib -j $(nproc)
+        make prefix=/usr/local/glibc lib=lib -j $(nproc)
     install:
       - |
         make DESTDIR=/rootfs prefix=/usr/local lib=lib install

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libseccomp/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libseccomp/pkg.yaml
@@ -21,7 +21,7 @@ steps:
         cd build
 
         ../configure \
-            --prefix=/usr/local
+            --prefix=/usr/local/glibc
     build:
       - |
         cd build

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libtirpc/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libtirpc/pkg.yaml
@@ -19,7 +19,7 @@ steps:
         tar -xf libtirpc.tar.bz2 --strip-components=1
 
         ./configure \
-          --prefix=/usr/local \
+          --prefix=/usr/local/glibc \
           --disable-gssapi
     build:
       - |

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/pkg.yaml
@@ -40,7 +40,7 @@ steps:
       WITH_LIBELF: yes
       WITH_TIRPC: no # setting no means we'll use the system libtirpc
       WITH_SECCOMP: yes
-      PKG_CONFIG_PATH: /usr/local/lib/pkgconfig # to find runtime libraries compiled in extensions (libseccomp)
+      PKG_CONFIG_PATH: /usr/local/glibc/lib/pkgconfig # to find runtime libraries compiled in extensions (libseccomp)
       PATH: "/usr/bin:{{ .PATH }}" # bldr doesn't have /usr/bin in PATH
     prepare:
       - |
@@ -50,8 +50,8 @@ steps:
       - |
         cd libnvidia-container
 
-        # LDLIBS=-L/usr/local/lib is set so that libnvidia-container-cli libs which are hardcoded as -llibname and not using pkg-config
-        CPPFLAGS="-I/usr/local/include/tirpc" LDLIBS="-L/usr/local/lib -ltirpc" make
+        # LDLIBS=-L/usr/local/glibc/lib is set so that libnvidia-container-cli libs which are hardcoded as -llibname and not using pkg-config
+        CPPFLAGS="-I/usr/local/glibc/include/tirpc" LDLIBS="-L/usr/local/glibc/lib -ltirpc -lelf -lseccomp" make
     install:
       - |
         mkdir -p /rootfs

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/zlib/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/zlib/pkg.yaml
@@ -19,7 +19,7 @@ steps:
         cd build
 
         ../configure \
-            --prefix=/usr/local
+            --prefix=/usr/local/glibc
     build:
       - |
         cd build
@@ -29,7 +29,7 @@ steps:
         cd build
         make DESTDIR=/rootfs install
         # we only need the libs and headers, remove everything else
-        find /rootfs/usr/local/ -type d \( -name bin -o -name sbin -o -name share \) -prune -exec rm -rf {} \;
+        find /rootfs/usr/local/glibc -type d \( -name bin -o -name sbin -o -name share \) -prune -exec rm -rf {} \;
 finalize:
   - from: /rootfs
     to: /rootfs

--- a/storage/zfs/zfs-tools/libtirpc/pkg.yaml
+++ b/storage/zfs/zfs-tools/libtirpc/pkg.yaml
@@ -26,7 +26,7 @@ steps:
         export CFLAGS="${CFLAGS} -I/usr/local/include"
 
         ./configure \
-          --prefix=/usr/local/libtirpc \
+          --prefix=/usr/local \
           --disable-gssapi
     build:
       - |

--- a/storage/zfs/zfs-tools/pkg.yaml
+++ b/storage/zfs/zfs-tools/pkg.yaml
@@ -20,8 +20,6 @@ steps:
         tar -xf zfs.tar.gz --strip-components=1
     build:
       - |
-        export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/local/libtirpc/lib/pkgconfig
-
         ./configure \
           --prefix=/usr/local \
           --with-udevdir=/usr/local/sbin \


### PR DESCRIPTION
Introduce a proper fix for #401, keep musl path's as is, and use `/usr/local/glibc` as install path for all glibc related stuff so that any new common libraries will not cause an issue in the future.
