### PR TITLE
chore: drop `/proc` mounts.

### DIFF
--- a/storage/iscsi-tools/tgtd.yaml
+++ b/storage/iscsi-tools/tgtd.yaml
@@ -32,13 +32,6 @@ container:
         - rshared
         - rbind
         - rw
-    - source: /proc
-      destination: /proc
-      type: bind
-      options:
-        - rshared
-        - rbind
-        - rw
     - source: /usr/local/sbin
       destination: /usr/local/sbin
       type: bind

--- a/storage/zfs/zpool-importer.yaml
+++ b/storage/zfs/zpool-importer.yaml
@@ -44,13 +44,6 @@ container:
         - rshared
         - rbind
         - rw
-    - source: /proc
-      destination: /proc
-      type: bind
-      options:
-        - rshared
-        - rbind
-        - rw
     - source: /var
       destination: /var
       type: bind


### PR DESCRIPTION
We don't need these proc mounts anymore, also having them `rshared` causes weird issues with volume discovery.