### PR TITLE
fix: tgtd mount propagation

### DIFF
--- a/storage/iscsi-tools/tgtd.yaml
+++ b/storage/iscsi-tools/tgtd.yaml
@@ -7,6 +7,8 @@ depends:
        - hostname
        - etcfiles
 container:
+  security:
+    rootfsPropagation: shared
   entrypoint: /usr/local/sbin/tgtd
   args:
     - -f


### PR DESCRIPTION
With #411 `/proc` mounts were dropped, but we need to set proper mount propagation, otherwise shutdown hangs for a long time.