### PR TITLE
feat(mdadm): configure mdadm.conf path for use with extensionconfig

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-01T17:25:51Z by kres faf91e3.
+# Generated on 2024-09-13T08:39:30Z by kres 8be5fa7.
 
 policies:
   - type: commit
@@ -12,7 +12,7 @@ policies:
           gitHubOrganization: siderolabs
       spellcheck:
         locale: US
-      maximumOfOneCommit: true
+      maximumOfOneCommit: false
       header:
         length: 89
         imperative: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-29T14:13:04Z by kres b5ca957.
+# Generated on 2024-10-08T16:19:09Z by kres 34e72ac.
 
 name: default
 concurrency:
@@ -33,7 +33,7 @@ jobs:
       labels: ${{ steps.retrieve-pr-labels.outputs.result }}
     services:
       buildkitd:
-        image: moby/buildkit:v0.15.2
+        image: moby/buildkit:v0.16.0
         options: --privileged
         ports:
           - 1234:1234
@@ -143,7 +143,7 @@ jobs:
       - default
     services:
       buildkitd:
-        image: moby/buildkit:v0.15.2
+        image: moby/buildkit:v0.16.0
         options: --privileged
         ports:
           - 1234:1234

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-29T14:13:04Z by kres b5ca957.
+# Generated on 2024-10-08T16:19:09Z by kres 34e72ac.
 
 name: weekly
 concurrency:
@@ -16,7 +16,7 @@ jobs:
       - pkgs
     services:
       buildkitd:
-        image: moby/buildkit:v0.15.2
+        image: moby/buildkit:v0.16.0
         options: --privileged
         ports:
           - 1234:1234

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -60,7 +60,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.8.0-4-g736ecae
+        defaultValue: v1.8.0-7-g800cca0
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
   useBldrPkgTagResolver: true

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -60,7 +60,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.8.0
+        defaultValue: v1.8.0-4-g736ecae
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
   useBldrPkgTagResolver: true
@@ -162,3 +162,7 @@ spec:
           cosign verify $$image --certificate-identity-regexp '@siderolabs\.com$$' --certificate-oidc-issuer https://accounts.google.com || \
             cosign sign --yes $$image; \
         done
+---
+kind: common.Repository
+spec:
+  conformMaximumOfOneCommit: false

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -60,7 +60,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.8.0-8-gdf1a1a5
+        defaultValue: v1.8.0-16-g71d23b4
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
   useBldrPkgTagResolver: true

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -60,7 +60,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.8.0-7-g800cca0
+        defaultValue: v1.8.0-8-gdf1a1a5
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
   useBldrPkgTagResolver: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,165 @@
+## [Talos System Extensions 1.8.0-beta.1](https://github.com/siderolabs/extensions/releases/tag/v1.8.0-beta.1) (2024-09-16)
+
+Welcome to the v1.8.0-beta.1 release of Talos System Extensions!  
+*This is a pre-release of Talos System Extensions*
+
+See [Talos Linux documentation](https://www.talos.dev/v1.8/talos-guides/configuration/system-extensions/) for information on using system extensions.
+
+Please try out the release binaries and report any issues at
+https://github.com/siderolabs/extensions/issues.
+
+### CRUN Container Runtime
+
+CRUN container runtime is now shipped as a Talos System Extension
+
+
+### Gvisor Container Runtime
+
+Gvisor now ships an additional runtime using `kvm` as the sandboxing mechanism.
+
+
+### Intel Management Engine
+
+Intel Management Engine (IME) modules is now shipped as a Talos System Extension.
+
+
+### NVIDIA Driver and Container Toolkit
+
+The NVIDIA drivers and the container toolkits now ships an LTS and Production version as per https://docs.nvidia.com/datacenter/tesla/drivers/index.html#lifecycle.
+
+The new extensions are named below:
+
+* nvidia-container-toolkit-production
+* nvidia-container-toolkit-lts
+* nvidia-open-gpu-kernel-modules-production
+* nvidia-open-gpu-kernel-modules-lts
+* nonfree-kmod-nvidia-lts
+* nonfree-kmod-nvidia-production
+
+The extensions would ship the latest version of LTS/Production drivers available at the time of Talos release.
+
+Image Factory using an existing schematic id would upgrade the NVIDIA driver and container toolkit to the LTS version.
+
+If production version is required, the schematic id should be updated to the production version.
+
+
+### Component Updates
+
+ZFS: 2.2.6
+DRBD: 9.2.11
+gasket: 5815ee3
+Tailscale: 1.70.0
+ecr-credential-provider: 1.31.0
+qemu-guest-agent: 9.1.0
+mdadm: 4.3
+Intel microcode: 20240910
+Linux firmware: 20240811
+Spin: 0.15.1
+Gvisor: 20240729.0
+Wasmedge: v0.4.0
+Kata Containers: 3.3.0
+NVIDIA container toolkit: v1.16.1
+iscsi-tools: v0.1.5
+vmtoolsd: v0.6.0
+util-linux-tools: 2.40.2
+
+
+### Contributors
+
+* Andrey Smirnov
+* Noel Georgi
+* Rui Lopes
+* Bernard Gütermann
+* David Peralta
+* Dmitriy Matrenichev
+* Henrik Gerdes
+* Judah Rand
+* Kingdon Barrett
+* Mark S
+* Markus Reiter
+* Mathieu Dallaire
+* Mike Beaumont
+* Nick Meyer
+* Sheogorath
+* Sven Pfennig
+* Tobias Bradtke
+
+### Changes
+<details><summary>54 commits</summary>
+<p>
+
+* [`9c6ab75`](https://github.com/siderolabs/extensions/commit/9c6ab7570a21374f6cde9590d7000302d4a0618c) feat: update Intel u-code to 20240910
+* [`f6b8647`](https://github.com/siderolabs/extensions/commit/f6b86471d05bce40d1b8e5153aca520b61fea990) chore: disable max of one commit
+* [`8c38348`](https://github.com/siderolabs/extensions/commit/8c38348174bdc21cc80b4ab1f046657eeed67be8) release(v1.8.0-beta.0): prepare release
+* [`bf3c9d2`](https://github.com/siderolabs/extensions/commit/bf3c9d2db1ccc6551750d0ecf6e686aa81331514) feat: update depenendencies
+* [`6bca19f`](https://github.com/siderolabs/extensions/commit/6bca19f8b8b2f49284c7014fe881dab7248013e5) release(v1.8.0-alpha.2): prepare release
+* [`d33d428`](https://github.com/siderolabs/extensions/commit/d33d428dbf0df0cc6845174c7a607c61556d05ee) feat: add `uinput` driver extension
+* [`4563de5`](https://github.com/siderolabs/extensions/commit/4563de58b26e1a9d6990e590e2afaf26602306d2) feat: bump dependencies
+* [`e753a74`](https://github.com/siderolabs/extensions/commit/e753a74ee12a1715e9d6da7ef253cb255fe40038) chore: add MAINTAINERS file
+* [`bb94c9d`](https://github.com/siderolabs/extensions/commit/bb94c9d65a46caf2f2d03e191dab677d45f976f4) fix(stargz): set default root path
+* [`a5a6365`](https://github.com/siderolabs/extensions/commit/a5a636538dfccbef0dfd536511a81cf24a26199a) chore: add missing license
+* [`5f4947e`](https://github.com/siderolabs/extensions/commit/5f4947e28adedceb45ee610a456ad8b83cbe3240) docs: fix link to kspp page
+* [`03337d7`](https://github.com/siderolabs/extensions/commit/03337d706dd6148bd7e0a0350c43031b78ff58c1) chore: bump deps
+* [`cac285c`](https://github.com/siderolabs/extensions/commit/cac285cbd24e086af09df99a0b602538b70afd3a) chore: bump deps
+* [`d6c324d`](https://github.com/siderolabs/extensions/commit/d6c324dc1f65cd2f0ffa25f6b7e24991923fc1c2) chore: bump deps
+* [`37f2297`](https://github.com/siderolabs/extensions/commit/37f2297e6bdcc8fdc1eb5efcf166dfd4534bf261) feat: support lts and production nvidia modules
+* [`6e6f029`](https://github.com/siderolabs/extensions/commit/6e6f0293e138ebc1d3e4a15106614a46d386488c) docs: update README and release notes
+* [`26c505d`](https://github.com/siderolabs/extensions/commit/26c505db8cd83dd5aa7534440b7f467a6b4fa58e) feat: add crun container-runtime extension
+* [`c002fba`](https://github.com/siderolabs/extensions/commit/c002fbaf4853f433b4b86598311e74e2c87a4974) feat(mei): add extension to provide Intel Management Engine drivers
+* [`ab77645`](https://github.com/siderolabs/extensions/commit/ab77645a00cb074e2b52338540bca9a0cca72a6f) fix: update CRI config parts for containerd config v3
+* [`c536209`](https://github.com/siderolabs/extensions/commit/c536209ef820ab59b5a653fa451027f82c433352) feat(gvisor): add new runtime class with kvm support
+* [`b48d3a6`](https://github.com/siderolabs/extensions/commit/b48d3a65e6e9f57d0a54a58a1edbc8a735d900c8) chore: update extensions validator
+* [`807f599`](https://github.com/siderolabs/extensions/commit/807f59946ce986089fb2664eca31639ec6531302) release(v1.8.0-alpha.1): prepare release
+* [`d6773dd`](https://github.com/siderolabs/extensions/commit/d6773dd25aba4f101c2f49b251ea0a67ba242869) chore: bump deps
+* [`86511df`](https://github.com/siderolabs/extensions/commit/86511dff5bea2964987bd750c31ddba3bf3e214a) chore: update spin extension to v0.15.0
+* [`5334e89`](https://github.com/siderolabs/extensions/commit/5334e89374e6fb0766e25b0e702647908f4abfc0) fix: glibc search paths for nvidia
+* [`3197e22`](https://github.com/siderolabs/extensions/commit/3197e22a3121f71dde52a78792f67962696496b9) docs: improve `nut-client` docs
+* [`f0b6082`](https://github.com/siderolabs/extensions/commit/f0b6082466dc78a309d1e9a7d8525497d714d4d4) chore: bump tailscale to v1.68.1
+* [`8e946d6`](https://github.com/siderolabs/extensions/commit/8e946d688f52e689fa447bc0daecf09fe84623b0) fix: tgtd mount propagation
+* [`5904e12`](https://github.com/siderolabs/extensions/commit/5904e12cec3312c4808e9c65c94a6c555d17caa3) chore: add cache paths for go builds
+* [`b840088`](https://github.com/siderolabs/extensions/commit/b84008881c27a419e8153aa4d8332a5a59717734) chore: drop `/proc` mounts
+* [`3526f45`](https://github.com/siderolabs/extensions/commit/3526f4507a568bc2d6101ab1d15c9b29ddea47eb) fix: zfs extensions with nvidia
+* [`13f56fc`](https://github.com/siderolabs/extensions/commit/13f56fcac088dc8ba61198e15c633781d2e6ee20) chore: rename talos-vmtoolsd -> vmtoolsd-guest-agent
+* [`5e92a6c`](https://github.com/siderolabs/extensions/commit/5e92a6cb93f14fbef5230816b98d45f6366ab020) chore: use fedora mirror for glibc
+* [`4ed9ee5`](https://github.com/siderolabs/extensions/commit/4ed9ee584987bf47e20246680081d589b664a413) fix: zfs-tools libtirpc path
+* [`cce3b41`](https://github.com/siderolabs/extensions/commit/cce3b415e07a471d53d41b188a7c325ccc6a4d27) fix: gvisor-debug extension
+* [`d07caf7`](https://github.com/siderolabs/extensions/commit/d07caf7eed782732f09427f863d23e0dffe9c034) chore: add extensions validator
+* [`d1a0ce8`](https://github.com/siderolabs/extensions/commit/d1a0ce88c4e25e63cbe6e9664c621b75dea505bd) feat: include nsenter when building util-linux binaries
+* [`8abfa20`](https://github.com/siderolabs/extensions/commit/8abfa2085a1737b32a61ee7c6d20e93de3dd3d94) chore(ci): drop drone
+* [`7f39bce`](https://github.com/siderolabs/extensions/commit/7f39bceabb076b9157cb19c335956f51d5ad6849) feat: update Linux firmware to 20240513
+* [`44a6ab1`](https://github.com/siderolabs/extensions/commit/44a6ab1ec6fdf97c1902e92c330fc75bb8e52a93) feat: update Intel u-code to 20240514
+* [`d6f0b54`](https://github.com/siderolabs/extensions/commit/d6f0b546612bb9a3cf5fc0d1689d59a8308b1259) chore: update spin extension to v0.14.1
+* [`01808ff`](https://github.com/siderolabs/extensions/commit/01808ff2feef6d4bd29bfde10dca102219d5b2f7) feat: update mdadm to 4.3
+* [`2f97116`](https://github.com/siderolabs/extensions/commit/2f97116a50ee6b8cb6f1dd44f53a3db031a35711) feat: update dependencies
+* [`dffe8b9`](https://github.com/siderolabs/extensions/commit/dffe8b9546a4ca20640c3754460b457814db16f2) fix: extension name in manifests
+* [`d21bc48`](https://github.com/siderolabs/extensions/commit/d21bc482678c030957cff4ada882afcd372f8ab5) feat: update zfs extension to v2.2.4
+* [`80c5113`](https://github.com/siderolabs/extensions/commit/80c5113abfabdd868a069410bcd86cdeec790b48) release(v1.8.0-alpha.0): prepare release
+* [`dd85754`](https://github.com/siderolabs/extensions/commit/dd8575455e1aaf2eff31f0217bffc15d9d6450d3) fix: rekres the repo after pkgs bump
+* [`d589ad0`](https://github.com/siderolabs/extensions/commit/d589ad0d7955a3437063dcaabc21d9b68816eff1) release(v1.8.0-alpha.0): prepare release
+* [`882b4ac`](https://github.com/siderolabs/extensions/commit/882b4ac9f59d0daf4e5bbd5d15ae80861a778de3) fix: version in util-linux manifest
+* [`4df073a`](https://github.com/siderolabs/extensions/commit/4df073ab7f5cc5d037a466e048144b57d655e408) chore(ci): only build amd64 for extensions e2e
+* [`69fe96c`](https://github.com/siderolabs/extensions/commit/69fe96ccc330ac84bcbc265a4a95bd35cfe0df2a) docs: improve ExtensionServiceConfig docs
+* [`8672c3b`](https://github.com/siderolabs/extensions/commit/8672c3baf51f36a9e796b0532db0f1159847cf4d) chore: update pkgs version to the latest
+* [`76d3797`](https://github.com/siderolabs/extensions/commit/76d3797fedad56cbe1c0a9ba85328ac9f545ce35) docs: update Spin README.md
+* [`213ef32`](https://github.com/siderolabs/extensions/commit/213ef326c12bcf0a97f8fd29caa46ff40c96a310) feat: add spin wasm runtime
+</p>
+</details>
+
+### Changes since v1.8.0-beta.0
+<details><summary>2 commits</summary>
+<p>
+
+* [`9c6ab75`](https://github.com/siderolabs/extensions/commit/9c6ab7570a21374f6cde9590d7000302d4a0618c) feat: update Intel u-code to 20240910
+* [`f6b8647`](https://github.com/siderolabs/extensions/commit/f6b86471d05bce40d1b8e5153aca520b61fea990) chore: disable max of one commit
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+
+Previous release can be found at [v1.7.0](https://github.com/siderolabs/extensions/releases/tag/v1.7.0)
+
 ## [Talos System Extensions 1.8.0-beta.0](https://github.com/siderolabs/extensions/releases/tag/v1.8.0-beta.0) (2024-09-09)
 
 Welcome to the v1.8.0-beta.0 release of Talos System Extensions!  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,169 @@
+## [Talos System Extensions 1.8.0](https://github.com/siderolabs/extensions/releases/tag/v1.8.0) (2024-09-23)
+
+Welcome to the v1.8.0 release of Talos System Extensions!
+
+See [Talos Linux documentation](https://www.talos.dev/v1.8/talos-guides/configuration/system-extensions/) for information on using system extensions.
+
+Please try out the release binaries and report any issues at
+https://github.com/siderolabs/extensions/issues.
+
+### CRUN Container Runtime
+
+CRUN container runtime is now shipped as a Talos System Extension
+
+
+### Gvisor Container Runtime
+
+Gvisor now ships an additional runtime using `kvm` as the sandboxing mechanism.
+
+
+### Intel Management Engine
+
+Intel Management Engine (IME) modules is now shipped as a Talos System Extension.
+
+
+### NVIDIA Driver and Container Toolkit
+
+The NVIDIA drivers and the container toolkits now ships an LTS and Production version as per https://docs.nvidia.com/datacenter/tesla/drivers/index.html#lifecycle.
+
+The new extensions are named below:
+
+* nvidia-container-toolkit-production
+* nvidia-container-toolkit-lts
+* nvidia-open-gpu-kernel-modules-production
+* nvidia-open-gpu-kernel-modules-lts
+* nonfree-kmod-nvidia-lts
+* nonfree-kmod-nvidia-production
+
+The extensions would ship the latest version of LTS/Production drivers available at the time of Talos release.
+
+Image Factory using an existing schematic id would upgrade the NVIDIA driver and container toolkit to the LTS version.
+
+If production version is required, the schematic id should be updated to the production version.
+
+
+### Component Updates
+
+ZFS: 2.2.6
+DRBD: 9.2.11
+gasket: 5815ee3
+Tailscale: 1.70.0
+ecr-credential-provider: 1.31.0
+qemu-guest-agent: 9.1.0
+mdadm: 4.3
+Intel microcode: 20240910
+Linux firmware: 20240909
+Spin: 0.15.1
+Gvisor: 20240729.0
+Wasmedge: v0.4.0
+Kata Containers: 3.3.0
+NVIDIA container toolkit: v1.16.1
+iscsi-tools: v0.1.5
+vmtoolsd: v0.6.0
+util-linux-tools: 2.40.2
+
+
+### Contributors
+
+* Andrey Smirnov
+* Noel Georgi
+* Rui Lopes
+* Bernard Gütermann
+* David Peralta
+* Dmitriy Matrenichev
+* Henrik Gerdes
+* Judah Rand
+* Kingdon Barrett
+* Mark S
+* Markus Reiter
+* Mathieu Dallaire
+* Mike Beaumont
+* Nick Meyer
+* Sheogorath
+* Sven Pfennig
+* Tobias Bradtke
+
+### Changes
+<details><summary>58 commits</summary>
+<p>
+
+* [`10b0aae`](https://github.com/siderolabs/extensions/commit/10b0aae14655561e84ca4a341db00f61de06c734) fix: zfs extensions service yaml to proper path
+* [`2a5b58d`](https://github.com/siderolabs/extensions/commit/2a5b58d137ce2f8a82729432ecf48b782dd40186) feat: update pkgs/Linux firmware
+* [`da9acaa`](https://github.com/siderolabs/extensions/commit/da9acaa28348f09a666d609d5fef2fd441e7a9de) fix: image reproducibility with finalize
+* [`c65a147`](https://github.com/siderolabs/extensions/commit/c65a147c2d027590e136b19611ed013503f03e35) release(v1.8.0-beta.1): prepare release
+* [`9c6ab75`](https://github.com/siderolabs/extensions/commit/9c6ab7570a21374f6cde9590d7000302d4a0618c) feat: update Intel u-code to 20240910
+* [`f6b8647`](https://github.com/siderolabs/extensions/commit/f6b86471d05bce40d1b8e5153aca520b61fea990) chore: disable max of one commit
+* [`8c38348`](https://github.com/siderolabs/extensions/commit/8c38348174bdc21cc80b4ab1f046657eeed67be8) release(v1.8.0-beta.0): prepare release
+* [`bf3c9d2`](https://github.com/siderolabs/extensions/commit/bf3c9d2db1ccc6551750d0ecf6e686aa81331514) feat: update depenendencies
+* [`6bca19f`](https://github.com/siderolabs/extensions/commit/6bca19f8b8b2f49284c7014fe881dab7248013e5) release(v1.8.0-alpha.2): prepare release
+* [`d33d428`](https://github.com/siderolabs/extensions/commit/d33d428dbf0df0cc6845174c7a607c61556d05ee) feat: add `uinput` driver extension
+* [`4563de5`](https://github.com/siderolabs/extensions/commit/4563de58b26e1a9d6990e590e2afaf26602306d2) feat: bump dependencies
+* [`e753a74`](https://github.com/siderolabs/extensions/commit/e753a74ee12a1715e9d6da7ef253cb255fe40038) chore: add MAINTAINERS file
+* [`bb94c9d`](https://github.com/siderolabs/extensions/commit/bb94c9d65a46caf2f2d03e191dab677d45f976f4) fix(stargz): set default root path
+* [`a5a6365`](https://github.com/siderolabs/extensions/commit/a5a636538dfccbef0dfd536511a81cf24a26199a) chore: add missing license
+* [`5f4947e`](https://github.com/siderolabs/extensions/commit/5f4947e28adedceb45ee610a456ad8b83cbe3240) docs: fix link to kspp page
+* [`03337d7`](https://github.com/siderolabs/extensions/commit/03337d706dd6148bd7e0a0350c43031b78ff58c1) chore: bump deps
+* [`cac285c`](https://github.com/siderolabs/extensions/commit/cac285cbd24e086af09df99a0b602538b70afd3a) chore: bump deps
+* [`d6c324d`](https://github.com/siderolabs/extensions/commit/d6c324dc1f65cd2f0ffa25f6b7e24991923fc1c2) chore: bump deps
+* [`37f2297`](https://github.com/siderolabs/extensions/commit/37f2297e6bdcc8fdc1eb5efcf166dfd4534bf261) feat: support lts and production nvidia modules
+* [`6e6f029`](https://github.com/siderolabs/extensions/commit/6e6f0293e138ebc1d3e4a15106614a46d386488c) docs: update README and release notes
+* [`26c505d`](https://github.com/siderolabs/extensions/commit/26c505db8cd83dd5aa7534440b7f467a6b4fa58e) feat: add crun container-runtime extension
+* [`c002fba`](https://github.com/siderolabs/extensions/commit/c002fbaf4853f433b4b86598311e74e2c87a4974) feat(mei): add extension to provide Intel Management Engine drivers
+* [`ab77645`](https://github.com/siderolabs/extensions/commit/ab77645a00cb074e2b52338540bca9a0cca72a6f) fix: update CRI config parts for containerd config v3
+* [`c536209`](https://github.com/siderolabs/extensions/commit/c536209ef820ab59b5a653fa451027f82c433352) feat(gvisor): add new runtime class with kvm support
+* [`b48d3a6`](https://github.com/siderolabs/extensions/commit/b48d3a65e6e9f57d0a54a58a1edbc8a735d900c8) chore: update extensions validator
+* [`807f599`](https://github.com/siderolabs/extensions/commit/807f59946ce986089fb2664eca31639ec6531302) release(v1.8.0-alpha.1): prepare release
+* [`d6773dd`](https://github.com/siderolabs/extensions/commit/d6773dd25aba4f101c2f49b251ea0a67ba242869) chore: bump deps
+* [`86511df`](https://github.com/siderolabs/extensions/commit/86511dff5bea2964987bd750c31ddba3bf3e214a) chore: update spin extension to v0.15.0
+* [`5334e89`](https://github.com/siderolabs/extensions/commit/5334e89374e6fb0766e25b0e702647908f4abfc0) fix: glibc search paths for nvidia
+* [`3197e22`](https://github.com/siderolabs/extensions/commit/3197e22a3121f71dde52a78792f67962696496b9) docs: improve `nut-client` docs
+* [`f0b6082`](https://github.com/siderolabs/extensions/commit/f0b6082466dc78a309d1e9a7d8525497d714d4d4) chore: bump tailscale to v1.68.1
+* [`8e946d6`](https://github.com/siderolabs/extensions/commit/8e946d688f52e689fa447bc0daecf09fe84623b0) fix: tgtd mount propagation
+* [`5904e12`](https://github.com/siderolabs/extensions/commit/5904e12cec3312c4808e9c65c94a6c555d17caa3) chore: add cache paths for go builds
+* [`b840088`](https://github.com/siderolabs/extensions/commit/b84008881c27a419e8153aa4d8332a5a59717734) chore: drop `/proc` mounts
+* [`3526f45`](https://github.com/siderolabs/extensions/commit/3526f4507a568bc2d6101ab1d15c9b29ddea47eb) fix: zfs extensions with nvidia
+* [`13f56fc`](https://github.com/siderolabs/extensions/commit/13f56fcac088dc8ba61198e15c633781d2e6ee20) chore: rename talos-vmtoolsd -> vmtoolsd-guest-agent
+* [`5e92a6c`](https://github.com/siderolabs/extensions/commit/5e92a6cb93f14fbef5230816b98d45f6366ab020) chore: use fedora mirror for glibc
+* [`4ed9ee5`](https://github.com/siderolabs/extensions/commit/4ed9ee584987bf47e20246680081d589b664a413) fix: zfs-tools libtirpc path
+* [`cce3b41`](https://github.com/siderolabs/extensions/commit/cce3b415e07a471d53d41b188a7c325ccc6a4d27) fix: gvisor-debug extension
+* [`d07caf7`](https://github.com/siderolabs/extensions/commit/d07caf7eed782732f09427f863d23e0dffe9c034) chore: add extensions validator
+* [`d1a0ce8`](https://github.com/siderolabs/extensions/commit/d1a0ce88c4e25e63cbe6e9664c621b75dea505bd) feat: include nsenter when building util-linux binaries
+* [`8abfa20`](https://github.com/siderolabs/extensions/commit/8abfa2085a1737b32a61ee7c6d20e93de3dd3d94) chore(ci): drop drone
+* [`7f39bce`](https://github.com/siderolabs/extensions/commit/7f39bceabb076b9157cb19c335956f51d5ad6849) feat: update Linux firmware to 20240513
+* [`44a6ab1`](https://github.com/siderolabs/extensions/commit/44a6ab1ec6fdf97c1902e92c330fc75bb8e52a93) feat: update Intel u-code to 20240514
+* [`d6f0b54`](https://github.com/siderolabs/extensions/commit/d6f0b546612bb9a3cf5fc0d1689d59a8308b1259) chore: update spin extension to v0.14.1
+* [`01808ff`](https://github.com/siderolabs/extensions/commit/01808ff2feef6d4bd29bfde10dca102219d5b2f7) feat: update mdadm to 4.3
+* [`2f97116`](https://github.com/siderolabs/extensions/commit/2f97116a50ee6b8cb6f1dd44f53a3db031a35711) feat: update dependencies
+* [`dffe8b9`](https://github.com/siderolabs/extensions/commit/dffe8b9546a4ca20640c3754460b457814db16f2) fix: extension name in manifests
+* [`d21bc48`](https://github.com/siderolabs/extensions/commit/d21bc482678c030957cff4ada882afcd372f8ab5) feat: update zfs extension to v2.2.4
+* [`80c5113`](https://github.com/siderolabs/extensions/commit/80c5113abfabdd868a069410bcd86cdeec790b48) release(v1.8.0-alpha.0): prepare release
+* [`dd85754`](https://github.com/siderolabs/extensions/commit/dd8575455e1aaf2eff31f0217bffc15d9d6450d3) fix: rekres the repo after pkgs bump
+* [`d589ad0`](https://github.com/siderolabs/extensions/commit/d589ad0d7955a3437063dcaabc21d9b68816eff1) release(v1.8.0-alpha.0): prepare release
+* [`882b4ac`](https://github.com/siderolabs/extensions/commit/882b4ac9f59d0daf4e5bbd5d15ae80861a778de3) fix: version in util-linux manifest
+* [`4df073a`](https://github.com/siderolabs/extensions/commit/4df073ab7f5cc5d037a466e048144b57d655e408) chore(ci): only build amd64 for extensions e2e
+* [`69fe96c`](https://github.com/siderolabs/extensions/commit/69fe96ccc330ac84bcbc265a4a95bd35cfe0df2a) docs: improve ExtensionServiceConfig docs
+* [`8672c3b`](https://github.com/siderolabs/extensions/commit/8672c3baf51f36a9e796b0532db0f1159847cf4d) chore: update pkgs version to the latest
+* [`76d3797`](https://github.com/siderolabs/extensions/commit/76d3797fedad56cbe1c0a9ba85328ac9f545ce35) docs: update Spin README.md
+* [`213ef32`](https://github.com/siderolabs/extensions/commit/213ef326c12bcf0a97f8fd29caa46ff40c96a310) feat: add spin wasm runtime
+</p>
+</details>
+
+### Changes since v1.8.0-beta.1
+<details><summary>3 commits</summary>
+<p>
+
+* [`10b0aae`](https://github.com/siderolabs/extensions/commit/10b0aae14655561e84ca4a341db00f61de06c734) fix: zfs extensions service yaml to proper path
+* [`2a5b58d`](https://github.com/siderolabs/extensions/commit/2a5b58d137ce2f8a82729432ecf48b782dd40186) feat: update pkgs/Linux firmware
+* [`da9acaa`](https://github.com/siderolabs/extensions/commit/da9acaa28348f09a666d609d5fef2fd441e7a9de) fix: image reproducibility with finalize
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+
+Previous release can be found at [v1.7.0](https://github.com/siderolabs/extensions/releases/tag/v1.7.0)
+
 ## [Talos System Extensions 1.8.0-beta.1](https://github.com/siderolabs/extensions/releases/tag/v1.8.0-beta.1) (2024-09-16)
 
 Welcome to the v1.8.0-beta.1 release of Talos System Extensions!  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## [Talos System Extensions 1.8.1](https://github.com/siderolabs/extensions/releases/tag/v1.8.1) (2024-10-08)
+
+Welcome to the v1.8.1 release of Talos System Extensions!
+
+See [Talos Linux documentation](https://www.talos.dev/v1.8/talos-guides/configuration/system-extensions/) for information on using system extensions.
+
+Please try out the release binaries and report any issues at
+https://github.com/siderolabs/extensions/issues.
+
+### Contributors
+
+* Andrey Smirnov
+
+### Changes
+<details><summary>1 commit</summary>
+<p>
+
+* [`5fe0170`](https://github.com/siderolabs/extensions/commit/5fe0170b3cc73fed64ba165adb8e9e507b1f1556) release(v1.8.1): prepare release
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+
+Previous release can be found at [v1.8.0](https://github.com/siderolabs/extensions/releases/tag/v1.8.0)
+
 ## [Talos System Extensions 1.8.0](https://github.com/siderolabs/extensions/releases/tag/v1.8.0) (2024-09-23)
 
 Welcome to the v1.8.0 release of Talos System Extensions!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,161 @@
+## [Talos System Extensions 1.8.0-beta.0](https://github.com/siderolabs/extensions/releases/tag/v1.8.0-beta.0) (2024-09-09)
+
+Welcome to the v1.8.0-beta.0 release of Talos System Extensions!  
+*This is a pre-release of Talos System Extensions*
+
+See [Talos Linux documentation](https://www.talos.dev/v1.8/talos-guides/configuration/system-extensions/) for information on using system extensions.
+
+Please try out the release binaries and report any issues at
+https://github.com/siderolabs/extensions/issues.
+
+### CRUN Container Runtime
+
+CRUN container runtime is now shipped as a Talos System Extension
+
+
+### Gvisor Container Runtime
+
+Gvisor now ships an additional runtime using `kvm` as the sandboxing mechanism.
+
+
+### Intel Management Engine
+
+Intel Management Engine (IME) modules is now shipped as a Talos System Extension.
+
+
+### NVIDIA Driver and Container Toolkit
+
+The NVIDIA drivers and the container toolkits now ships an LTS and Production version as per https://docs.nvidia.com/datacenter/tesla/drivers/index.html#lifecycle.
+
+The new extensions are named below:
+
+* nvidia-container-toolkit-production
+* nvidia-container-toolkit-lts
+* nvidia-open-gpu-kernel-modules-production
+* nvidia-open-gpu-kernel-modules-lts
+* nonfree-kmod-nvidia-lts
+* nonfree-kmod-nvidia-production
+
+The extensions would ship the latest version of LTS/Production drivers available at the time of Talos release.
+
+Image Factory using an existing schematic id would upgrade the NVIDIA driver and container toolkit to the LTS version.
+
+If production version is required, the schematic id should be updated to the production version.
+
+
+### Component Updates
+
+ZFS: 2.2.6
+DRBD: 9.2.11
+gasket: 5815ee3
+Tailscale: 1.70.0
+ecr-credential-provider: 1.31.0
+qemu-guest-agent: 9.1.0
+mdadm: 4.3
+Intel microcode: 20240813
+Linux firmware: 20240811
+Spin: 0.15.1
+Gvisor: 20240729.0
+Wasmedge: v0.4.0
+Kata Containers: 3.3.0
+NVIDIA container toolkit: v1.16.1
+iscsi-tools: v0.1.5
+vmtoolsd: v0.6.0
+util-linux-tools: 2.40.2
+
+
+### Contributors
+
+* Noel Georgi
+* Andrey Smirnov
+* Rui Lopes
+* Bernard Gütermann
+* David Peralta
+* Dmitriy Matrenichev
+* Henrik Gerdes
+* Judah Rand
+* Kingdon Barrett
+* Mark S
+* Markus Reiter
+* Mathieu Dallaire
+* Mike Beaumont
+* Nick Meyer
+* Sheogorath
+* Sven Pfennig
+* Tobias Bradtke
+
+### Changes
+<details><summary>51 commits</summary>
+<p>
+
+* [`bf3c9d2`](https://github.com/siderolabs/extensions/commit/bf3c9d2db1ccc6551750d0ecf6e686aa81331514) feat: update depenendencies
+* [`6bca19f`](https://github.com/siderolabs/extensions/commit/6bca19f8b8b2f49284c7014fe881dab7248013e5) release(v1.8.0-alpha.2): prepare release
+* [`d33d428`](https://github.com/siderolabs/extensions/commit/d33d428dbf0df0cc6845174c7a607c61556d05ee) feat: add `uinput` driver extension
+* [`4563de5`](https://github.com/siderolabs/extensions/commit/4563de58b26e1a9d6990e590e2afaf26602306d2) feat: bump dependencies
+* [`e753a74`](https://github.com/siderolabs/extensions/commit/e753a74ee12a1715e9d6da7ef253cb255fe40038) chore: add MAINTAINERS file
+* [`bb94c9d`](https://github.com/siderolabs/extensions/commit/bb94c9d65a46caf2f2d03e191dab677d45f976f4) fix(stargz): set default root path
+* [`a5a6365`](https://github.com/siderolabs/extensions/commit/a5a636538dfccbef0dfd536511a81cf24a26199a) chore: add missing license
+* [`5f4947e`](https://github.com/siderolabs/extensions/commit/5f4947e28adedceb45ee610a456ad8b83cbe3240) docs: fix link to kspp page
+* [`03337d7`](https://github.com/siderolabs/extensions/commit/03337d706dd6148bd7e0a0350c43031b78ff58c1) chore: bump deps
+* [`cac285c`](https://github.com/siderolabs/extensions/commit/cac285cbd24e086af09df99a0b602538b70afd3a) chore: bump deps
+* [`d6c324d`](https://github.com/siderolabs/extensions/commit/d6c324dc1f65cd2f0ffa25f6b7e24991923fc1c2) chore: bump deps
+* [`37f2297`](https://github.com/siderolabs/extensions/commit/37f2297e6bdcc8fdc1eb5efcf166dfd4534bf261) feat: support lts and production nvidia modules
+* [`6e6f029`](https://github.com/siderolabs/extensions/commit/6e6f0293e138ebc1d3e4a15106614a46d386488c) docs: update README and release notes
+* [`26c505d`](https://github.com/siderolabs/extensions/commit/26c505db8cd83dd5aa7534440b7f467a6b4fa58e) feat: add crun container-runtime extension
+* [`c002fba`](https://github.com/siderolabs/extensions/commit/c002fbaf4853f433b4b86598311e74e2c87a4974) feat(mei): add extension to provide Intel Management Engine drivers
+* [`ab77645`](https://github.com/siderolabs/extensions/commit/ab77645a00cb074e2b52338540bca9a0cca72a6f) fix: update CRI config parts for containerd config v3
+* [`c536209`](https://github.com/siderolabs/extensions/commit/c536209ef820ab59b5a653fa451027f82c433352) feat(gvisor): add new runtime class with kvm support
+* [`b48d3a6`](https://github.com/siderolabs/extensions/commit/b48d3a65e6e9f57d0a54a58a1edbc8a735d900c8) chore: update extensions validator
+* [`807f599`](https://github.com/siderolabs/extensions/commit/807f59946ce986089fb2664eca31639ec6531302) release(v1.8.0-alpha.1): prepare release
+* [`d6773dd`](https://github.com/siderolabs/extensions/commit/d6773dd25aba4f101c2f49b251ea0a67ba242869) chore: bump deps
+* [`86511df`](https://github.com/siderolabs/extensions/commit/86511dff5bea2964987bd750c31ddba3bf3e214a) chore: update spin extension to v0.15.0
+* [`5334e89`](https://github.com/siderolabs/extensions/commit/5334e89374e6fb0766e25b0e702647908f4abfc0) fix: glibc search paths for nvidia
+* [`3197e22`](https://github.com/siderolabs/extensions/commit/3197e22a3121f71dde52a78792f67962696496b9) docs: improve `nut-client` docs
+* [`f0b6082`](https://github.com/siderolabs/extensions/commit/f0b6082466dc78a309d1e9a7d8525497d714d4d4) chore: bump tailscale to v1.68.1
+* [`8e946d6`](https://github.com/siderolabs/extensions/commit/8e946d688f52e689fa447bc0daecf09fe84623b0) fix: tgtd mount propagation
+* [`5904e12`](https://github.com/siderolabs/extensions/commit/5904e12cec3312c4808e9c65c94a6c555d17caa3) chore: add cache paths for go builds
+* [`b840088`](https://github.com/siderolabs/extensions/commit/b84008881c27a419e8153aa4d8332a5a59717734) chore: drop `/proc` mounts
+* [`3526f45`](https://github.com/siderolabs/extensions/commit/3526f4507a568bc2d6101ab1d15c9b29ddea47eb) fix: zfs extensions with nvidia
+* [`13f56fc`](https://github.com/siderolabs/extensions/commit/13f56fcac088dc8ba61198e15c633781d2e6ee20) chore: rename talos-vmtoolsd -> vmtoolsd-guest-agent
+* [`5e92a6c`](https://github.com/siderolabs/extensions/commit/5e92a6cb93f14fbef5230816b98d45f6366ab020) chore: use fedora mirror for glibc
+* [`4ed9ee5`](https://github.com/siderolabs/extensions/commit/4ed9ee584987bf47e20246680081d589b664a413) fix: zfs-tools libtirpc path
+* [`cce3b41`](https://github.com/siderolabs/extensions/commit/cce3b415e07a471d53d41b188a7c325ccc6a4d27) fix: gvisor-debug extension
+* [`d07caf7`](https://github.com/siderolabs/extensions/commit/d07caf7eed782732f09427f863d23e0dffe9c034) chore: add extensions validator
+* [`d1a0ce8`](https://github.com/siderolabs/extensions/commit/d1a0ce88c4e25e63cbe6e9664c621b75dea505bd) feat: include nsenter when building util-linux binaries
+* [`8abfa20`](https://github.com/siderolabs/extensions/commit/8abfa2085a1737b32a61ee7c6d20e93de3dd3d94) chore(ci): drop drone
+* [`7f39bce`](https://github.com/siderolabs/extensions/commit/7f39bceabb076b9157cb19c335956f51d5ad6849) feat: update Linux firmware to 20240513
+* [`44a6ab1`](https://github.com/siderolabs/extensions/commit/44a6ab1ec6fdf97c1902e92c330fc75bb8e52a93) feat: update Intel u-code to 20240514
+* [`d6f0b54`](https://github.com/siderolabs/extensions/commit/d6f0b546612bb9a3cf5fc0d1689d59a8308b1259) chore: update spin extension to v0.14.1
+* [`01808ff`](https://github.com/siderolabs/extensions/commit/01808ff2feef6d4bd29bfde10dca102219d5b2f7) feat: update mdadm to 4.3
+* [`2f97116`](https://github.com/siderolabs/extensions/commit/2f97116a50ee6b8cb6f1dd44f53a3db031a35711) feat: update dependencies
+* [`dffe8b9`](https://github.com/siderolabs/extensions/commit/dffe8b9546a4ca20640c3754460b457814db16f2) fix: extension name in manifests
+* [`d21bc48`](https://github.com/siderolabs/extensions/commit/d21bc482678c030957cff4ada882afcd372f8ab5) feat: update zfs extension to v2.2.4
+* [`80c5113`](https://github.com/siderolabs/extensions/commit/80c5113abfabdd868a069410bcd86cdeec790b48) release(v1.8.0-alpha.0): prepare release
+* [`dd85754`](https://github.com/siderolabs/extensions/commit/dd8575455e1aaf2eff31f0217bffc15d9d6450d3) fix: rekres the repo after pkgs bump
+* [`d589ad0`](https://github.com/siderolabs/extensions/commit/d589ad0d7955a3437063dcaabc21d9b68816eff1) release(v1.8.0-alpha.0): prepare release
+* [`882b4ac`](https://github.com/siderolabs/extensions/commit/882b4ac9f59d0daf4e5bbd5d15ae80861a778de3) fix: version in util-linux manifest
+* [`4df073a`](https://github.com/siderolabs/extensions/commit/4df073ab7f5cc5d037a466e048144b57d655e408) chore(ci): only build amd64 for extensions e2e
+* [`69fe96c`](https://github.com/siderolabs/extensions/commit/69fe96ccc330ac84bcbc265a4a95bd35cfe0df2a) docs: improve ExtensionServiceConfig docs
+* [`8672c3b`](https://github.com/siderolabs/extensions/commit/8672c3baf51f36a9e796b0532db0f1159847cf4d) chore: update pkgs version to the latest
+* [`76d3797`](https://github.com/siderolabs/extensions/commit/76d3797fedad56cbe1c0a9ba85328ac9f545ce35) docs: update Spin README.md
+* [`213ef32`](https://github.com/siderolabs/extensions/commit/213ef326c12bcf0a97f8fd29caa46ff40c96a310) feat: add spin wasm runtime
+</p>
+</details>
+
+### Changes since v1.8.0-alpha.2
+<details><summary>1 commit</summary>
+<p>
+
+* [`bf3c9d2`](https://github.com/siderolabs/extensions/commit/bf3c9d2db1ccc6551750d0ecf6e686aa81331514) feat: update depenendencies
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+
+Previous release can be found at [v1.7.0](https://github.com/siderolabs/extensions/releases/tag/v1.7.0)
+
 ## [Talos System Extensions 1.8.0-alpha.2](https://github.com/siderolabs/extensions/releases/tag/v1.8.0-alpha.2) (2024-08-30)
 
 Welcome to the v1.8.0-alpha.2 release of Talos System Extensions!  

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-23T12:40:47Z by kres 8be5fa7.
+# Generated on 2024-10-08T16:19:09Z by kres 34e72ac.
 
 # common variables
 
@@ -48,7 +48,7 @@ COMMON_ARGS += --build-arg=PKGS_PREFIX="$(PKGS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.8.0-8-gdf1a1a5
+PKGS ?= v1.8.0-16-g71d23b4
 PKGS_PREFIX ?= ghcr.io/siderolabs
 
 # targets defines all the available targets

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-06T11:07:46Z by kres 8be5fa7.
+# Generated on 2024-09-13T08:39:30Z by kres 8be5fa7.
 
 # common variables
 
@@ -48,7 +48,7 @@ COMMON_ARGS += --build-arg=PKGS_PREFIX="$(PKGS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.8.0
+PKGS ?= v1.8.0-4-g736ecae
 PKGS_PREFIX ?= ghcr.io/siderolabs
 
 # targets defines all the available targets

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-20T10:56:00Z by kres 8be5fa7.
+# Generated on 2024-09-23T12:40:47Z by kres 8be5fa7.
 
 # common variables
 
@@ -48,7 +48,7 @@ COMMON_ARGS += --build-arg=PKGS_PREFIX="$(PKGS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.8.0-7-g800cca0
+PKGS ?= v1.8.0-8-gdf1a1a5
 PKGS_PREFIX ?= ghcr.io/siderolabs
 
 # targets defines all the available targets

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-13T08:39:30Z by kres 8be5fa7.
+# Generated on 2024-09-20T10:56:00Z by kres 8be5fa7.
 
 # common variables
 
@@ -48,7 +48,7 @@ COMMON_ARGS += --build-arg=PKGS_PREFIX="$(PKGS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.8.0-4-g736ecae
+PKGS ?= v1.8.0-7-g800cca0
 PKGS_PREFIX ?= ghcr.io/siderolabs
 
 # targets defines all the available targets

--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  LINUX_FIRMWARE_VERSION: "20240811" # update this when updating PKGS_VERSION in Makefile
+  LINUX_FIRMWARE_VERSION: "20240909" # update this when updating PKGS_VERSION in Makefile
   DRBD_DRIVER_VERSION: 9.2.11 # update this when updating PKGS_VERSION in Makefile
   ZFS_DRIVER_VERSION: 2.2.6 # update this when updating PKGS_VERSION in Makefile
   UTIL_LINUX_VERSION: 2.40.2 # update this when updating PKGS_VERSION in Makefile

--- a/container-runtime/crun/pkg.yaml
+++ b/container-runtime/crun/pkg.yaml
@@ -24,6 +24,10 @@ steps:
         mkdir -p /rootfs/usr/local/bin
         cp -av crun /rootfs/usr/local/bin/crun
         chmod +x /rootfs/usr/local/bin/crun
+
+      - |
+        mkdir -p /rootfs/etc/cri/conf.d
+        cp /pkg/crun.part /rootfs/etc/cri/conf.d/crun.part
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -36,5 +40,3 @@ finalize:
     to: /rootfs
   - from: /pkg/manifest.yaml
     to: /
-  - from: /pkg/crun.part
-    to: /rootfs/etc/cri/conf.d/crun.part

--- a/container-runtime/gvisor/pkg.yaml
+++ b/container-runtime/gvisor/pkg.yaml
@@ -44,6 +44,11 @@ steps:
 
         cp ./bin/containerd-shim-runsc-v1 /rootfs/usr/local/bin/containerd-shim-runsc-v1
         chmod +x /rootfs/usr/local/bin/containerd-shim-runsc-v1
+
+      - |
+        mkdir -p /rootfs/etc/cri/conf.d
+
+        cp /pkg/gvisor.part /pkg/runsc.toml /pkg/gvisor-kvm.part /pkg/runsc-kvm.toml /rootfs/etc/cri/conf.d/
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -55,11 +60,3 @@ finalize:
     to: /rootfs
   - from: /pkg/manifest.yaml
     to: /
-  - from: /pkg/gvisor.part
-    to: /rootfs/etc/cri/conf.d/gvisor.part
-  - from: /pkg/runsc.toml
-    to: /rootfs/etc/cri/conf.d/runsc.toml
-  - from: /pkg/gvisor-kvm.part
-    to: /rootfs/etc/cri/conf.d/gvisor-kvm.part
-  - from: /pkg/runsc-kvm.toml
-    to: /rootfs/etc/cri/conf.d/runsc-kvm.toml

--- a/container-runtime/kata-containers/pkg.yaml
+++ b/container-runtime/kata-containers/pkg.yaml
@@ -59,6 +59,12 @@ steps:
       - |
         cd ${GOPATH}/src/github.com/kata-containers/src/runtime
         cp containerd-shim-kata-v2 /rootfs/usr/local/bin/containerd-shim-kata-v2
+      - |
+        mkdir -p /rootfs/etc/cri/conf.d
+        cp /pkg/kata-containers.part /rootfs/etc/cri/conf.d/kata-containers.part
+
+        mkdir -p /rootfs/usr/local/share/kata-containers
+        cp /pkg/configuration.toml /rootfs/usr/local/share/kata-containers/configuration.toml
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -70,7 +76,3 @@ finalize:
     to: /rootfs
   - from: /pkg/manifest.yaml
     to: /
-  - from: /pkg/kata-containers.part
-    to: /rootfs/etc/cri/conf.d/kata-containers.part
-  - from: /pkg/configuration.toml
-    to: /rootfs/usr/local/share/kata-containers/configuration.toml

--- a/container-runtime/spin/pkg.yaml
+++ b/container-runtime/spin/pkg.yaml
@@ -24,6 +24,9 @@ steps:
         mkdir -p /rootfs/usr/local/bin
 
         tar xf containerd-shim-spin.tar.gz -C /rootfs/usr/local/bin
+      - |
+        mkdir -p /rootfs/etc/cri/conf.d
+        cp /pkg/spin.part /rootfs/etc/cri/conf.d/spin.part
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -35,5 +38,3 @@ finalize:
     to: /rootfs
   - from: /pkg/manifest.yaml
     to: /
-  - from: /pkg/spin.part
-    to: /rootfs/etc/cri/conf.d/spin.part

--- a/container-runtime/stargz-snapshotter/pkg.yaml
+++ b/container-runtime/stargz-snapshotter/pkg.yaml
@@ -41,6 +41,15 @@ steps:
 
         cp ./out/ctr-remote /rootfs/usr/local/lib/containers/stargz-snapshotter/ctr-remote
         chmod +x /rootfs/usr/local/lib/containers/stargz-snapshotter/ctr-remote
+      - |
+        mkdir -p /rootfs/etc/cri/conf.d
+        cp /pkg/stargz-snapshotter.part /rootfs/etc/cri/conf.d/stargz-snapshotter.part
+
+        mkdir -p /rootfs/usr/local/etc/containerd-stargz-grpc
+        cp /pkg/config.toml /rootfs/usr/local/etc/containerd-stargz-grpc/config.toml
+
+        mkdir -p /rootfs/usr/local/etc/containers
+        cp /pkg/stargz-snapshotter.yaml /rootfs/usr/local/etc/containers/
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -52,9 +61,3 @@ finalize:
     to: /rootfs
   - from: /pkg/manifest.yaml
     to: /
-  - from: /pkg/stargz-snapshotter.part
-    to: /rootfs/etc/cri/conf.d/stargz-snapshotter.part
-  - from: /pkg/config.toml
-    to: /rootfs/usr/local/etc/containerd-stargz-grpc/config.toml
-  - from: /pkg/stargz-snapshotter.yaml
-    to: /rootfs/usr/local/etc/containers/

--- a/examples/hello-world-service/pkg.yaml
+++ b/examples/hello-world-service/pkg.yaml
@@ -20,10 +20,13 @@ steps:
         CGO_ENABLED=0 go build -o ./hello-world .
     install:
       - |
-        mkdir -p /rootfs/usr/local/etc/containers
         mkdir -p /rootfs/usr/local/lib/containers/hello-world
 
         cp -p /pkg/src/hello-world /rootfs/usr/local/lib/containers/hello-world/
+      - |
+        mkdir -p /rootfs/usr/local/etc/containers
+
+        cp /pkg/hello-world.yaml /rootfs/usr/local/etc/containers/
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -35,5 +38,3 @@ finalize:
     to: /rootfs
   - from: /pkg/manifest.yaml
     to: /
-  - from: /pkg/hello-world.yaml
-    to: /rootfs/usr/local/etc/containers/

--- a/firmware/intel-ucode/pkg.yaml
+++ b/firmware/intel-ucode/pkg.yaml
@@ -7,8 +7,8 @@ steps:
   - sources:
       - url: https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/refs/tags/microcode-{{ .INTEL_UCODE_VERSION }}.tar.gz
         destination: intel-ucode.tar.gz
-        sha256: f46cfe1d8be8d3c2c5a0fb63fc4d48c7dd1444f34346f0e42ad92c706cb90e79
-        sha512: ba1fa7d9bed7d90756ea959f5878afca0deacc9b1e932a936a15d74a411b7efb6103a4af75dc3731d9cbb2e464439ce9a7d448f75bc6f38b616907ff6dec6ee3
+        sha256: 8b7582eac7e9a691356e18b3bdcbc7b2db09494e040ec980a4a5fb6d0da261bf
+        sha512: d996de4f045df33f4eb1a1dabfb2f55bd8941e8dc16241d7a6c361216f4b87b88c34ba57c88ee4d4b7b3cf2b3fac937c43806191681df031fa3d5cdd677a86fe
     prepare:
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml

--- a/firmware/vars.yaml
+++ b/firmware/vars.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-releases extractVersion=^microcode-(?<version>.*)$ depName=intel/Intel-Linux-Processor-Microcode-Data-Files
-INTEL_UCODE_VERSION: 20240813
+INTEL_UCODE_VERSION: 20240910

--- a/guest-agents/qemu-guest-agent/pkg.yaml
+++ b/guest-agents/qemu-guest-agent/pkg.yaml
@@ -63,6 +63,9 @@ steps:
         rmdir /rootfs/usr/local/share
         rmdir /rootfs/var/run
         rmdir /rootfs/var
+      - |
+        mkdir -p /rootfs/usr/local/etc/containers
+        cp /pkg/qemu-guest-agent.yaml /rootfs/usr/local/etc/containers/
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -74,5 +77,3 @@ finalize:
     to: /rootfs
   - from: /pkg/manifest.yaml
     to: /
-  - from: /pkg/qemu-guest-agent.yaml
-    to: /rootfs/usr/local/etc/containers/

--- a/guest-agents/xen-guest-agent/pkg.yaml
+++ b/guest-agents/xen-guest-agent/pkg.yaml
@@ -32,6 +32,10 @@ steps:
         containerRoot=/rootfs/usr/local/lib/containers/xen-guest-agent
         mkdir -p "$containerRoot"
         mv target/{{ .ARCH }}-alpine-linux-musl/release/xen-guest-agent "$containerRoot/xen-guest-agent"
+      - |
+        mkdir -p /rootfs/usr/local/etc/containers
+
+        cp /pkg/xen-guest-agent.yaml /rootfs/usr/local/etc/containers/
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -43,5 +47,3 @@ finalize:
     to: /rootfs
   - from: /pkg/manifest.yaml
     to: /
-  - from: /pkg/xen-guest-agent.yaml
-    to: /rootfs/usr/local/etc/containers/

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -64,7 +64,7 @@ Tailscale: 1.70.0
 ecr-credential-provider: 1.31.0
 qemu-guest-agent: 9.1.0
 mdadm: 4.3
-Intel microcode: 20240813
+Intel microcode: 20240910
 Linux firmware: 20240811
 Spin: 0.15.1
 Gvisor: 20240729.0

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -6,7 +6,7 @@ github_repo = "siderolabs/extensions"
 match_deps = "^github.com/((talos-systems|siderolabs)/[a-zA-Z0-9-]+)$"
 
 # previous release
-previous = "v1.7.0"
+previous = "v1.8.0"
 
 pre_release = false
 
@@ -15,66 +15,6 @@ See [Talos Linux documentation](https://www.talos.dev/v1.8/talos-guides/configur
 """
 
 [notes]
-    [notes.container-runtime-crun]
-        title = "CRUN Container Runtime"
-        description = """
-CRUN container runtime is now shipped as a Talos System Extension
-"""
-
-    [notes.container-runtime-gvisor]
-        title = "Gvisor Container Runtime"
-        description = """
-Gvisor now ships an additional runtime using `kvm` as the sandboxing mechanism.
-"""
-
-    [notes.intel-management-engine]
-        title = "Intel Management Engine"
-        description = """
-Intel Management Engine (IME) modules is now shipped as a Talos System Extension.
-"""
-
-    [notes.nvidia]
-        title = "NVIDIA Driver and Container Toolkit"
-        description = """
-The NVIDIA drivers and the container toolkits now ships an LTS and Production version as per https://docs.nvidia.com/datacenter/tesla/drivers/index.html#lifecycle.
-
-The new extensions are named below:
-
-* nvidia-container-toolkit-production
-* nvidia-container-toolkit-lts
-* nvidia-open-gpu-kernel-modules-production
-* nvidia-open-gpu-kernel-modules-lts
-* nonfree-kmod-nvidia-lts
-* nonfree-kmod-nvidia-production
-
-The extensions would ship the latest version of LTS/Production drivers available at the time of Talos release.
-
-Image Factory using an existing schematic id would upgrade the NVIDIA driver and container toolkit to the LTS version.
-
-If production version is required, the schematic id should be updated to the production version.
-"""
-
-[notes.updates]
-    title = "Component Updates"
-    description = """
-ZFS: 2.2.6
-DRBD: 9.2.11
-gasket: 5815ee3
-Tailscale: 1.70.0
-ecr-credential-provider: 1.31.0
-qemu-guest-agent: 9.1.0
-mdadm: 4.3
-Intel microcode: 20240910
-Linux firmware: 20240909
-Spin: 0.15.1
-Gvisor: 20240729.0
-Wasmedge: v0.4.0
-Kata Containers: 3.3.0
-NVIDIA container toolkit: v1.16.1
-iscsi-tools: v0.1.5
-vmtoolsd: v0.6.0
-util-linux-tools: 2.40.2
-"""
 
 
 [make_deps]

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -8,7 +8,7 @@ match_deps = "^github.com/((talos-systems|siderolabs)/[a-zA-Z0-9-]+)$"
 # previous release
 previous = "v1.7.0"
 
-pre_release = true
+pre_release = false
 
 preface = """\
 See [Talos Linux documentation](https://www.talos.dev/v1.8/talos-guides/configuration/system-extensions/) for information on using system extensions.

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -65,7 +65,7 @@ ecr-credential-provider: 1.31.0
 qemu-guest-agent: 9.1.0
 mdadm: 4.3
 Intel microcode: 20240910
-Linux firmware: 20240811
+Linux firmware: 20240909
 Spin: 0.15.1
 Gvisor: 20240729.0
 Wasmedge: v0.4.0

--- a/network/tailscale/pkg.yaml
+++ b/network/tailscale/pkg.yaml
@@ -37,6 +37,9 @@ steps:
         cp -pr dist/tailscale /rootfs/usr/local/lib/containers/tailscale/usr/local/bin
         cp -pr dist/tailscaled /rootfs/usr/local/lib/containers/tailscale/usr/local/bin
         cp -pr dist/containerboot /rootfs/usr/local/lib/containers/tailscale/usr/local/bin
+      - |
+        mkdir -p /rootfs/usr/local/etc/containers
+        cp /pkg/tailscale.yaml /rootfs/usr/local/etc/containers/
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -48,5 +51,3 @@ finalize:
     to: /rootfs
   - from: /pkg/manifest.yaml
     to: /
-  - from: /pkg/tailscale.yaml
-    to: /rootfs/usr/local/etc/containers/

--- a/nvidia-gpu/nvidia-container-toolkit/lts/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/lts/pkg.yaml
@@ -18,7 +18,9 @@ steps:
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
     install:
       - |
-        mkdir -p /rootfs
+        mkdir -p /rootfs/usr/local/etc/containers
+
+        cp /pkg/nvidia-persistenced.yaml /rootfs/usr/local/etc/containers/nvidia-persistenced.yaml
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -28,7 +30,5 @@ steps:
 finalize:
   - from: /rootfs
     to: /rootfs
-  - from: /pkg/nvidia-persistenced.yaml
-    to: /rootfs/usr/local/etc/containers/nvidia-persistenced.yaml
   - from: /pkg/manifest.yaml
     to: /

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/pkg.yaml
@@ -49,10 +49,12 @@ steps:
           ln -sv nvidia-container-runtime-wrapper /rootfs/usr/local/bin/$(basename $clean_file)
           cp $clean_file /rootfs/usr/local/bin/$(basename $clean_file).real
         done
+      - |
+        mkdir -p /rootfs/etc/cri/conf.d
+        cp /pkg/nvidia-container-runtime.part /rootfs/etc/cri/conf.d/nvidia-container-runtime.part
+
+        mkdir -p /rootfs/usr/local/etc/nvidia-container-runtime
+        cp /pkg/nvidia-container-runtime.toml /rootfs/usr/local/etc/nvidia-container-runtime/config.toml
 finalize:
   - from: /rootfs
     to: /rootfs
-  - from: /pkg/nvidia-container-runtime.part
-    to: /rootfs/etc/cri/conf.d/nvidia-container-runtime.part
-  - from: /pkg/nvidia-container-runtime.toml
-    to: /rootfs/usr/local/etc/nvidia-container-runtime/config.toml

--- a/nvidia-gpu/nvidia-container-toolkit/production/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/production/pkg.yaml
@@ -18,7 +18,8 @@ steps:
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
     install:
       - |
-        mkdir -p /rootfs
+        mkdir -p /rootfs/usr/local/etc/containers
+        cp /pkg/nvidia-persistenced.yaml /rootfs/usr/local/etc/containers/nvidia-persistenced.yaml
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -28,7 +29,5 @@ steps:
 finalize:
   - from: /rootfs
     to: /rootfs
-  - from: /pkg/nvidia-persistenced.yaml
-    to: /rootfs/usr/local/etc/containers/nvidia-persistenced.yaml
   - from: /pkg/manifest.yaml
     to: /

--- a/nvidia-gpu/nvidia-fabricmanager/lts/pkg.yaml
+++ b/nvidia-gpu/nvidia-fabricmanager/lts/pkg.yaml
@@ -40,6 +40,8 @@ steps:
 
         cp etc/fabricmanager.cfg  /rootfs/usr/local/share/nvidia/nvswitch/
 
+        cp /pkg/nvidia-fabricmanager.yaml /rootfs/usr/local/etc/containers/nvidia-fabricmanager.yaml
+
         sed -i 's/DAEMONIZE=.*/DAEMONIZE=0/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
         sed -i 's/STATE_FILE_NAME=.*/STATE_FILE_NAME=\/var\/run\/nvidia-fabricmanager\/fabricmanager.state/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
         sed -i 's/TOPOLOGY_FILE_PATH=.*/TOPOLOGY_FILE_PATH=\/usr\/local\/share\/nvidia\/nvswitch/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
@@ -53,7 +55,5 @@ steps:
 finalize:
   - from: /rootfs
     to: /rootfs
-  - from: /pkg/nvidia-fabricmanager.yaml
-    to: /rootfs/usr/local/etc/containers/nvidia-fabricmanager.yaml
   - from: /pkg/manifest.yaml
     to: /

--- a/nvidia-gpu/nvidia-fabricmanager/production/lts/pkg.yaml
+++ b/nvidia-gpu/nvidia-fabricmanager/production/lts/pkg.yaml
@@ -40,6 +40,8 @@ steps:
 
         cp etc/fabricmanager.cfg  /rootfs/usr/local/share/nvidia/nvswitch/
 
+        cp /pkg/nvidia-fabricmanager.yaml /rootfs/usr/local/etc/containers/nvidia-fabricmanager.yaml
+
         sed -i 's/DAEMONIZE=.*/DAEMONIZE=0/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
         sed -i 's/STATE_FILE_NAME=.*/STATE_FILE_NAME=\/var\/run\/nvidia-fabricmanager\/fabricmanager.state/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
         sed -i 's/TOPOLOGY_FILE_PATH=.*/TOPOLOGY_FILE_PATH=\/usr\/local\/share\/nvidia\/nvswitch/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
@@ -53,7 +55,5 @@ steps:
 finalize:
   - from: /rootfs
     to: /rootfs
-  - from: /pkg/nvidia-fabricmanager.yaml
-    to: /rootfs/usr/local/etc/containers/nvidia-fabricmanager.yaml
   - from: /pkg/manifest.yaml
     to: /

--- a/power/nut-client/pkg.yaml
+++ b/power/nut-client/pkg.yaml
@@ -80,6 +80,9 @@ steps:
         rm -rf /rootfs/usr/local/etc
         rm -rf /rootfs/usr/local/lib/nut
         rm -rf /rootfs/usr/local/sbin
+      - |
+        mkdir -p /rootfs/usr/local/etc/containers
+        cp /pkg/nut-client.yaml /rootfs/usr/local/etc/containers/
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -91,5 +94,3 @@ finalize:
     to: /rootfs
   - from: /pkg/manifest.yaml
     to: /
-  - from: /pkg/nut-client.yaml
-    to: /rootfs/usr/local/etc/containers/

--- a/storage/iscsi-tools/pkg.yaml
+++ b/storage/iscsi-tools/pkg.yaml
@@ -19,6 +19,11 @@ steps:
       # cleanup
       rm -rf /rootfs/usr/local/include
       rm -rf /rootfs/usr/share
+    - |
+      mkdir -p /rootfs/usr/local/etc/containers
+
+      cp /pkg/iscsid.yaml /rootfs/usr/local/etc/containers/iscsid.yaml
+      cp /pkg/tgtd.yaml /rootfs/usr/local/etc/containers/tgtd.yaml
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -26,10 +31,6 @@ steps:
         cp /pkg/manifest.yaml /extensions-validator-rootfs/manifest.yaml
         /extensions-validator validate --rootfs=/extensions-validator-rootfs --pkg-name="${PKG_NAME}"
 finalize:
-  - from: /pkg/iscsid.yaml
-    to: /rootfs/usr/local/etc/containers/iscsid.yaml
-  - from: /pkg/tgtd.yaml
-    to: /rootfs/usr/local/etc/containers/tgtd.yaml
   - from: /rootfs
     to: /rootfs
   - from: /pkg/manifest.yaml

--- a/storage/mdadm/files/udev-md-raid-arrays.rules
+++ b/storage/mdadm/files/udev-md-raid-arrays.rules
@@ -17,7 +17,7 @@ TEST!="md/array_state", GOTO="md_end"
 ATTR{md/array_state}=="clear*|inactive", GOTO="md_end"
 LABEL="md_ignore_state"
 
-IMPORT{program}="/usr/local/sbin/mdadm --detail --no-devices --export $devnode"
+IMPORT{program}="/usr/local/sbin/mdadm --detail -c /var/run/mdadm/mdadm.conf --no-devices --export $devnode"
 ENV{DEVTYPE}=="disk", ENV{MD_NAME}=="?*", SYMLINK+="disk/by-id/md-name-$env{MD_NAME}", OPTIONS+="string_escape=replace"
 ENV{DEVTYPE}=="disk", ENV{MD_UUID}=="?*", SYMLINK+="disk/by-id/md-uuid-$env{MD_UUID}"
 ENV{DEVTYPE}=="disk", ENV{MD_DEVNAME}=="?*", SYMLINK+="md/$env{MD_DEVNAME}"

--- a/storage/mdadm/files/udev-md-raid-arrays.rules
+++ b/storage/mdadm/files/udev-md-raid-arrays.rules
@@ -17,7 +17,7 @@ TEST!="md/array_state", GOTO="md_end"
 ATTR{md/array_state}=="clear*|inactive", GOTO="md_end"
 LABEL="md_ignore_state"
 
-IMPORT{program}="/usr/local/sbin/mdadm --detail -c /var/run/mdadm/mdadm.conf --no-devices --export $devnode"
+IMPORT{program}="/usr/local/sbin/mdadm --detail -c /var/lib/mdadm/mdadm.conf --no-devices --export $devnode"
 ENV{DEVTYPE}=="disk", ENV{MD_NAME}=="?*", SYMLINK+="disk/by-id/md-name-$env{MD_NAME}", OPTIONS+="string_escape=replace"
 ENV{DEVTYPE}=="disk", ENV{MD_UUID}=="?*", SYMLINK+="disk/by-id/md-uuid-$env{MD_UUID}"
 ENV{DEVTYPE}=="disk", ENV{MD_DEVNAME}=="?*", SYMLINK+="md/$env{MD_DEVNAME}"

--- a/storage/mdadm/files/udev-md-raid-assembly.rules
+++ b/storage/mdadm/files/udev-md-raid-assembly.rules
@@ -23,7 +23,7 @@ LABEL="md_inc"
 
 # remember you can limit what gets auto/incrementally assembled by
 # mdadm.conf(5)'s 'AUTO' and selectively whitelist using 'ARRAY'
-ACTION=="add|change", IMPORT{program}="/usr/local/sbin/mdadm --incremental --export $devnode --offroot $env{DEVLINKS}"
+ACTION=="add|change", IMPORT{program}="/usr/local/sbin/mdadm --incremental -c /var/run/mdadm/mdadm.conf --export $devnode --offroot $env{DEVLINKS}"
 ACTION=="remove", ENV{ID_PATH}=="?*", RUN+="/usr/local/sbin/mdadm -If $name --path $env{ID_PATH}"
 ACTION=="remove", ENV{ID_PATH}!="?*", RUN+="/usr/local/sbin/mdadm -If $name"
 

--- a/storage/mdadm/files/udev-md-raid-assembly.rules
+++ b/storage/mdadm/files/udev-md-raid-assembly.rules
@@ -23,7 +23,7 @@ LABEL="md_inc"
 
 # remember you can limit what gets auto/incrementally assembled by
 # mdadm.conf(5)'s 'AUTO' and selectively whitelist using 'ARRAY'
-ACTION=="add|change", IMPORT{program}="/usr/local/sbin/mdadm --incremental -c /var/run/mdadm/mdadm.conf --export $devnode --offroot $env{DEVLINKS}"
+ACTION=="add|change", IMPORT{program}="/usr/local/sbin/mdadm --incremental -c /var/lib/mdadm/mdadm.conf --export $devnode --offroot $env{DEVLINKS}"
 ACTION=="remove", ENV{ID_PATH}=="?*", RUN+="/usr/local/sbin/mdadm -If $name --path $env{ID_PATH}"
 ACTION=="remove", ENV{ID_PATH}!="?*", RUN+="/usr/local/sbin/mdadm -If $name"
 

--- a/storage/mdadm/patches/change-sysconfdir.patch
+++ b/storage/mdadm/patches/change-sysconfdir.patch
@@ -5,7 +5,7 @@
  PKG_CONFIG ?= pkg-config
  
 -SYSCONFDIR = /etc
-+SYSCONFDIR = /var/run/mdadm/
++SYSCONFDIR = /var/lib/mdadm/
  CONFFILE = $(SYSCONFDIR)/mdadm.conf
  CONFFILE2 = $(SYSCONFDIR)/mdadm/mdadm.conf
  MAILCMD =/usr/sbin/sendmail -t

--- a/storage/mdadm/patches/change-sysconfdir.patch
+++ b/storage/mdadm/patches/change-sysconfdir.patch
@@ -1,0 +1,11 @@
+--- mdadm.orig/Makefile
++++ mdadm/Makefile
+@@ -89,7 +89,7 @@
+ 
+ PKG_CONFIG ?= pkg-config
+ 
+-SYSCONFDIR = /etc
++SYSCONFDIR = /var/run/mdadm/
+ CONFFILE = $(SYSCONFDIR)/mdadm.conf
+ CONFFILE2 = $(SYSCONFDIR)/mdadm/mdadm.conf
+ MAILCMD =/usr/sbin/sendmail -t

--- a/storage/mdadm/pkg.yaml
+++ b/storage/mdadm/pkg.yaml
@@ -21,6 +21,7 @@ steps:
         patch -p1 < /pkg/patches/no-werror.patch
         patch -p1 < /pkg/patches/musl-125.patch
         patch -p1 < /pkg/patches/exit-gracefully-when-md-device-not-found.patch
+        patch -p1 < /pkg/patches/change-sysconfdir.patch
     build:
       - |
         mkdir -p /run/mdadm
@@ -35,6 +36,8 @@ steps:
         cp mdmon /rootfs/usr/local/sbin/mdmon
         cp /pkg/files/udev-md-raid-arrays.rules   /rootfs/usr/etc/udev/rules.d/63-md-raid-arrays.rules
         cp /pkg/files/udev-md-raid-assembly.rules /rootfs/usr/etc/udev/rules.d/64-md-raid-assembly.rules
+        mkdir /var/run/mdadm
+        touch /var/run/mdadm/mdadm.conf
     test:
       - |
         mkdir -p /extensions-validator-rootfs

--- a/storage/zfs/pkg.yaml
+++ b/storage/zfs/pkg.yaml
@@ -19,9 +19,9 @@ steps:
 
         cp -R /lib/modules/* /rootfs/lib/modules
       - |
-        mkdir -p /rootfs/usr/local/lib/containers
+        mkdir -p /rootfs/usr/local/etc/containers
 
-        cp /pkg/zpool-importer.yaml /rootfs/usr/local/lib/containers/zpool-importer.yaml
+        cp /pkg/zpool-importer.yaml /rootfs/usr/local/etc/containers/zpool-importer.yaml
     test:
       - |
         mkdir -p /extensions-validator-rootfs

--- a/storage/zfs/pkg.yaml
+++ b/storage/zfs/pkg.yaml
@@ -18,6 +18,10 @@ steps:
         mkdir -p /rootfs/lib/modules /rootfs/usr/local/lib/containers/zpool-importer
 
         cp -R /lib/modules/* /rootfs/lib/modules
+      - |
+        mkdir -p /rootfs/usr/local/lib/containers
+
+        cp /pkg/zpool-importer.yaml /rootfs/usr/local/lib/containers/zpool-importer.yaml
     test:
       - |
         mkdir -p /extensions-validator-rootfs
@@ -29,5 +33,3 @@ finalize:
     to: /rootfs
   - from: /pkg/manifest.yaml
     to: /
-  - from: /pkg/zpool-importer.yaml
-    to: /rootfs/usr/local/etc/containers/zpool-importer.yaml


### PR DESCRIPTION
Add configuration (patch) so that mdadm reads the config file from /usr/local/etc/mdadm.conf instead of /etc/mdadm.conf