### PR TITLE
feat(gvisor): Add new runtime class with KVM support

### DIFF
--- a/container-runtime/gvisor/README.md
+++ b/container-runtime/gvisor/README.md
@@ -19,6 +19,8 @@ machine:
 
 ## Testing
 
+### default
+
 Apply the following manifest to run nginx pod via gVisor:
 
 ```yaml
@@ -46,3 +48,34 @@ $ kubectl get pods
 NAME           READY   STATUS    RESTARTS   AGE
 nginx-gvisor   1/1     Running   0          40s
 ```
+
+### With platform KVM (requires nested virtualization or bare-metal)
+
+Apply the following manifest to run nginx pod via gVisor with kvm platform:
+
+```yaml
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+handler: runsc-kvm
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-gvisor
+spec:
+  runtimeClassName: gvisor
+  containers:
+  - name: nginx
+    image: nginx
+```
+The pod should be up and running:
+
+```bash
+$ kubectl get pods
+NAME           READY   STATUS    RESTARTS   AGE
+nginx-gvisor   1/1     Running   0          40s
+```
+
+**Hint**: You can run both runtime handlers in parallel by naming them different

--- a/container-runtime/gvisor/gvisor-kvm.part
+++ b/container-runtime/gvisor/gvisor-kvm.part
@@ -1,0 +1,6 @@
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc-kvm]
+  runtime_type = "io.containerd.runsc.v1"
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc-kvm.options]
+  TypeUrl = "io.containerd.runsc.v1.options"
+  ConfigPath = "/etc/cri/conf.d/runsc-kvm.toml"

--- a/container-runtime/gvisor/pkg.yaml
+++ b/container-runtime/gvisor/pkg.yaml
@@ -59,3 +59,7 @@ finalize:
     to: /rootfs/etc/cri/conf.d/gvisor.part
   - from: /pkg/runsc.toml
     to: /rootfs/etc/cri/conf.d/runsc.toml
+  - from: /pkg/gvisor-kvm.part
+    to: /rootfs/etc/cri/conf.d/gvisor-kvm.part
+  - from: /pkg/runsc-kvm.toml
+    to: /rootfs/etc/cri/conf.d/runsc-kvm.toml

--- a/container-runtime/gvisor/runsc-kvm.toml
+++ b/container-runtime/gvisor/runsc-kvm.toml
@@ -1,0 +1,2 @@
+[runsc_config]
+  platform = "kvm"


### PR DESCRIPTION
This patch adds a new runtime class to the gvisor extension allowing to
use the KVM platform feature. This is done by selecting `runsc-kvm` as
runtime.