### PR TITLE
fix: update CRI config parts for containerd config v3

### DIFF
--- a/container-runtime/gvisor/gvisor-kvm.part
+++ b/container-runtime/gvisor/gvisor-kvm.part
@@ -1,6 +1,6 @@
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc-kvm]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc-kvm]
   runtime_type = "io.containerd.runsc.v1"
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc-kvm.options]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc-kvm.options]
   TypeUrl = "io.containerd.runsc.v1.options"
   ConfigPath = "/etc/cri/conf.d/runsc-kvm.toml"

--- a/container-runtime/gvisor/gvisor.part
+++ b/container-runtime/gvisor/gvisor.part
@@ -1,6 +1,6 @@
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc]
   runtime_type = "io.containerd.runsc.v1"
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc.options]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc.options]
   TypeUrl = "io.containerd.runsc.v1.options"
   ConfigPath = "/etc/cri/conf.d/runsc.toml"

--- a/container-runtime/kata-containers/kata-containers.part
+++ b/container-runtime/kata-containers/kata-containers.part
@@ -1,6 +1,6 @@
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
   pod_annotations = ["io.katacontainers.*"]
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.kata.options]
   ConfigPath = "/usr/local/share/kata-containers/configuration.toml"

--- a/container-runtime/spin/spin.part
+++ b/container-runtime/spin/spin.part
@@ -1,2 +1,2 @@
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.spin]
   runtime_type = "io.containerd.spin.v2"

--- a/container-runtime/stargz-snapshotter/stargz-snapshotter.part
+++ b/container-runtime/stargz-snapshotter/stargz-snapshotter.part
@@ -1,5 +1,5 @@
 # Enable stargz snapshotter for CRI
-[plugins."io.containerd.grpc.v1.cri".containerd]
+[plugins."io.containerd.cri.v1.runtime".containerd]
   snapshotter = "stargz"
   disable_snapshot_annotations = false
 

--- a/container-runtime/wasmedge/wasm.part
+++ b/container-runtime/wasmedge/wasm.part
@@ -1,2 +1,2 @@
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasmedge]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.wasmedge]
   runtime_type = "io.containerd.wasmedge.v1"

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/nvidia-container-runtime.part
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/nvidia-container-runtime.part
@@ -1,7 +1,7 @@
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
   privileged_without_host_devices = false
   runtime_engine = ""
   runtime_root = ""
   runtime_type = "io.containerd.runc.v2"
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
+  [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia.options]
     BinaryName = "/usr/local/bin/nvidia-container-runtime"


### PR DESCRIPTION
The CRI plugin name got changed.

See https://github.com/siderolabs/talos/pull/9078