### PR TITLE
feat: add crun container-runtime extension

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,6 +51,7 @@
             "matchPackageNames": [
                 "nvidia/open-gpu-kernel-modules",
                 "open-iscsi/open-isns",
+                "containers/crun",
                 "git://git.kernel.org/pub/scm/libs/libcap/libcap.git",
                 "git://sourceware.org/git/elfutils.git",
                 "git://git.kernel.org/pub/scm/utils/mdadm/mdadm.git"

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ TARGETS += drbd
 TARGETS += ecr-credential-provider
 TARGETS += fuse3
 TARGETS += gasket-driver
+TARGETS += crun
 TARGETS += gvisor
 TARGETS += gvisor-debug
 TARGETS += hello-world-service

--- a/container-runtime/crun/README.md
+++ b/container-runtime/crun/README.md
@@ -1,0 +1,43 @@
+# crun extension
+
+## Installation
+
+See [Installing Extensions](https://github.com/siderolabs/extensions#installing-extensions).
+
+## Usage
+
+In order to create the Wasm workload, a runtimeclass needs to be created.
+
+```yaml
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: crun
+handler: crun
+```
+
+## Testing
+
+Apply the following manifest to run nginx pod via crun:
+
+```yaml
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-crun
+spec:
+  runtimeClassName: crun
+  containers:
+  - name: nginx
+    image: nginx
+```
+
+The pod should be up and running:
+
+```bash
+$ kubectl get pods
+NAME           READY   STATUS    RESTARTS   AGE
+nginx-crun   1/1     Running   0          40s
+```

--- a/container-runtime/crun/crun.part
+++ b/container-runtime/crun/crun.part
@@ -1,0 +1,5 @@
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.crun]
+  runtime_type = "io.containerd.runc.v2"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.crun.options]
+  BinaryName = "/usr/local/bin/crun"

--- a/container-runtime/crun/manifest.yaml
+++ b/container-runtime/crun/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: crun
+  version: "$VERSION"
+  author: Henrik Gerdes
+  description: |
+    This system extension provides crun using containerd's runtime handler.
+  compatibility:
+    talos:
+      version: ">= v1.8.0"

--- a/container-runtime/crun/pkg.yaml
+++ b/container-runtime/crun/pkg.yaml
@@ -1,0 +1,40 @@
+name: crun
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - sources:
+      # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+      - url: https://github.com/containers/crun/releases/download/{{ .CRUN_VERSION }}/crun-{{ .CRUN_VERSION }}-linux-arm64-disable-systemd
+        destination: crun
+        sha256: 1bd840c95e9ae8edc25654dcf2481309724b9ff18ce95dbcd2535da9b026a47d
+        sha512: 3184eb0e440d9551003b4275c69ecaaef2ffaf84b11ac3ffdea2e22cc9d8c578bce032331bd476bf47e5d2247f0604b93b46c6a5c3225d6704378380d15d29ee
+      # {{ else }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+      - url: https://github.com/containers/crun/releases/download/{{ .CRUN_VERSION }}/crun-{{ .CRUN_VERSION }}-linux-amd64-disable-systemd
+        destination: crun
+        sha256: 03fd3ec6a7799183eaeefba5ebd3f66f9b5fb41a5b080c196285879631ff5dc1
+        sha512: 1989c491593691527f368cd13e56aa179a414ac31a789ee39c1646b7468cc7c32bbcf0cc7e26b90c53152936422fb12d699dd5654a11e1ed2f2c2dd7eb4588e7
+    # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+    prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+    install:
+      - |
+        mkdir -p /rootfs/usr/local/bin
+        cp -av crun /rootfs/usr/local/bin/crun
+        chmod +x /rootfs/usr/local/bin/crun
+    test:
+      - |
+        mkdir -p /extensions-validator-rootfs
+        cp -r /rootfs/ /extensions-validator-rootfs/rootfs
+        cp /pkg/manifest.yaml /extensions-validator-rootfs/manifest.yaml
+        /extensions-validator validate --rootfs=/extensions-validator-rootfs --pkg-name="${PKG_NAME}"
+
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /
+  - from: /pkg/crun.part
+    to: /rootfs/etc/cri/conf.d/crun.part

--- a/container-runtime/crun/vars.yaml
+++ b/container-runtime/crun/vars.yaml
@@ -1,0 +1,1 @@
+VERSION: "{{ .CRUN_VERSION }}"

--- a/container-runtime/vars.yaml
+++ b/container-runtime/vars.yaml
@@ -10,3 +10,5 @@ WASMEDGE_VERSION: v0.4.0
 SPIN_VERSION: v0.15.0
 # renovate: datasource=github-releases depName=kata-containers/kata-containers
 KATA_CONTAINERS_VERSION: 3.3.0
+# renovate: datasource=github-releases depName=containers/crun
+CRUN_VERSION: 1.15


### PR DESCRIPTION
**About:**

This adds the [crun](https://github.com/containers/crun) container runtime-class to talos sytsem extentions.  
crun is a alternative implementation of the container-runtime-interface (cri) written in C.

It claims to 50% faster but the difference I conduced by a recent performance comparison between different cri's was 21% faster runc and it required less memory making it a great choice for low end and embedded systems.

**Tests:**
I created my own talos system image for the hetzner cloud (for amd64 & arm64) and created a cluster with this extension. With the RuntimeClass for crun applied I was able to create container just like the defualt runc cri.

For a quick test the vm-images assets in [this](https://github.com/hegerdes/helper-suite/releases/tag/v2024.07.01) GitHub release can be used to test the extention on hetzner.  
*Note:* The images were build bevor the changes regarding containerd config changes in ab77645a00cb074e2b52338540bca9a0cca72a6f and with the v1.7 PKGS

A pre-build docker image with the extentions file can be found [here](https://hub.docker.com/r/hegerdes/crun).