### PR TITLE
chore: bump deps

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -9,6 +9,7 @@ spec:
     - btrfs
     - chelsio-drivers
     - chelsio-firmware
+    - crun
     - drbd
     - ecr-credential-provider
     - fuse3

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ TARGETS += bnx2-bnx2x
 TARGETS += btrfs
 TARGETS += chelsio-drivers
 TARGETS += chelsio-firmware
+TARGETS += crun
 TARGETS += drbd
 TARGETS += ecr-credential-provider
 TARGETS += fuse3

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,12 +1,12 @@
-# syntax = ghcr.io/siderolabs/bldr:v0.3.1
+# syntax = ghcr.io/siderolabs/bldr:v0.3.2
 
 format: v1alpha2
 
 vars:
-  LINUX_FIRMWARE_VERSION: "20240513" # update this when updating PKGS_VERSION in Makefile
+  LINUX_FIRMWARE_VERSION: "20240709" # update this when updating PKGS_VERSION in Makefile
   DRBD_DRIVER_VERSION: 9.2.9 # update this when updating PKGS_VERSION in Makefile
   ZFS_DRIVER_VERSION: 2.2.4 # update this when updating PKGS_VERSION in Makefile
-  UTIL_LINUX_VERSION: 2.40.1 # update this when updating PKGS_VERSION in Makefile
+  UTIL_LINUX_VERSION: 2.40.2 # update this when updating PKGS_VERSION in Makefile
 
   # renovate: datasource=git-tags extractVersion=^libtiprc-(?<version>.*)$ depName=git://linux-nfs.org/~steved/libtirpc
   LIBTIRPC_VERSION: 1-3-3

--- a/container-runtime/ecr-credential-provider/pkg.yaml
+++ b/container-runtime/ecr-credential-provider/pkg.yaml
@@ -7,8 +7,8 @@ steps:
   - sources:
       - url: https://github.com/kubernetes/cloud-provider-aws/archive/refs/tags/{{ .VERSION }}.tar.gz
         destination: cloud-provider-aws.tar.gz
-        sha256: a0ffe8b6a505f5238d4e8dc46df84c5227f41c05b539e2e7d8adf6b5eda1f0f8
-        sha512: 78ab4b188deee8e27a32280efc6dfca83f3bfd4e2235ed34555a1013760e1cc6c502b5a0609c99e1736c09bf0a0817aabfb0446d064954c14a87577c69bd38ff
+        sha256: 53ad64af7118449a4d732f82df7b3aeb4eb1551aabf48a213596bd2e662376e2
+        sha512: aa351cd531e452dd4ccead4a591a9161a25737ada93a7317c5c181c3d4fe55b279e94b686d8c03665ebee01191129a52b01c9dabfba7075c5e9bde52e6a341c8
     env:
       GOPATH: /go
     cachePaths:

--- a/container-runtime/gvisor/pkg.yaml
+++ b/container-runtime/gvisor/pkg.yaml
@@ -7,10 +7,10 @@ steps:
   - sources:
       # gvisor repo 'master' branch is Bazel-bazed, so we need to find matching commit in the "go" branch
       # find the go-branch specific merge commit ("Merge release-... (automated)") which has the release-tagged commit as a parent
-      - url: https://github.com/google/gvisor/archive/dfeb44ecf5accd9039f5b31a988f6dc39e2bd557.tar.gz
+      - url: https://github.com/google/gvisor/archive/3f38cb19ba373b027f5220450591daa3ab767145.tar.gz
         destination: gvisor.tar.gz
-        sha256: bf5ac3d0a9473ab2961ec2f1819b7ff665846ce8305d6bba2537938310e3a062
-        sha512: 42549911c63f203aa704ae7dea80f73364c812471d45b33f95a7769d4dbb26734669ba1f509c2f1804935e43f871b05d4054d9ea2ababaebfc1861b93e993d1c
+        sha256: ea4429edfa1c8ac811236557ca87f935de189d6108b0743261f907788b0b7257
+        sha512: 6eebda6c6a42235d678587501003cd5a34490ac4c2bb594c6c51bc3c17f87d49100d3892d82eaf2cdebb29c2b5902574ab82130cabc145bfdfca75c689b7d247
     env:
       GOPATH: /go
     cachePaths:

--- a/container-runtime/spin/pkg.yaml
+++ b/container-runtime/spin/pkg.yaml
@@ -8,13 +8,13 @@ steps:
     # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
       - url: https://github.com/spinkube/containerd-shim-spin/releases/download/{{ .SPIN_VERSION }}/containerd-shim-spin-v2-linux-aarch64.tar.gz
         destination: containerd-shim-spin.tar.gz
-        sha256: d86ab14d87c24003641be3545aeff8ece2ccc5e5b676ee6dffa10659b12a6ec9
-        sha512: 51d601b5dfaa2e7d358eb4f1077641e74654a6de8964ad7230be08cbd3fa968f9ae77ed3300bb5a1dc12ddeae3a3b4f42d5f2ed4a09a0e4e674597ded708b092
+        sha256: 8ed092c7020b439985cad81653d76043aee9549319d47541529e240d3690dec9
+        sha512: 9fbf9822408725839bd75f56793e4b94ab136b96d9a86ee80b23a156bc5416d2ad5e485513523de93d4a192f8d294c43b94ce03e819e37ce3354c056cd98b24e
     # {{ else }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
       - url: https://github.com/spinkube/containerd-shim-spin/releases/download/{{ .SPIN_VERSION }}/containerd-shim-spin-v2-linux-x86_64.tar.gz
         destination: containerd-shim-spin.tar.gz
-        sha256: f1ff91cbd05edb59c19468d62c1b34189a38f985dc0e1bcb3e0c992db83ffcb4
-        sha512: 62634b0c1f753b010fadbcc2b969006074937a5ccb20027affcc860e3dc7c8c6ba2cf09359a0bd3443aebb99168ae148c09183fcd7541a1eab29a71dfb159cce
+        sha256: 81d79fdbf3bff9433586222f5443a69ce6b690172f32cfc92ed3306125d5db15
+        sha512: 281e30a1183cb3197fb624b37b0b94abad3ccfe549b1f4fbf939bc461246712fe4b24cf2369deaa96be6397aa41f32d350540e19ff460da7fb3f96c4c01d11f1
     # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
     prepare:
       - |

--- a/container-runtime/vars.yaml
+++ b/container-runtime/vars.yaml
@@ -1,13 +1,13 @@
 # renovate: datasource=github-tags extractVersion=^release-(?<version>.*)$ depName=google/gvisor
-GVISOR_VERSION: 20240624.0
+GVISOR_VERSION: 20240729.0
 # renovate: datasource=github-releases depName=containerd/stargz-snapshotter
 STARGZ_SNAPSHOTTER_VERSION: v0.15.1
 # renovate: datasource=github-releases depName=kubernetes/cloud-provider-aws
-CLOUD_PROVIDER_AWS_VERSION: v1.30.2
+CLOUD_PROVIDER_AWS_VERSION: v1.30.3
 # renovate: datasource=git-tags extractVersion=^containerd-shim-wasmedge\/(?<version>.*)$ depName=https://github.com/containerd/runwasi.git
 WASMEDGE_VERSION: v0.4.0
 # renovate: datasource=git-tags depName=https://github.com/spinkube/containerd-shim-spin.git
-SPIN_VERSION: v0.15.0
+SPIN_VERSION: v0.15.1
 # renovate: datasource=github-releases depName=kata-containers/kata-containers
 KATA_CONTAINERS_VERSION: 3.3.0
 # renovate: datasource=github-releases depName=containers/crun

--- a/examples/hello-world-service/src/go.mod
+++ b/examples/hello-world-service/src/go.mod
@@ -1,3 +1,3 @@
 module github.com/siderolabs/hello-world
 
-go 1.21
+go 1.22

--- a/guest-agents/qemu-guest-agent/glib/pkg.yaml
+++ b/guest-agents/qemu-guest-agent/glib/pkg.yaml
@@ -9,8 +9,8 @@ steps:
   - sources:
       - url: https://download.gnome.org/sources/glib/{{ regexReplaceAll ".\\d+$" .GLIB_VERSION "${1}" }}/glib-{{ .GLIB_VERSION }}.tar.xz
         destination: glib.tar.xz
-        sha256: 1665188ed9cc941c0a189dc6295e6859872523d1bfc84a5a84732a7ae87b02e4
-        sha512: 545a9a98253f07d6a4c68bcdc377c9c1affe22504e4059bc5d385cb913a7e58d1bd2c09aa33c315871fc2c17b43e9d74bec4b8dcadb950920da31a79c8defe7e
+        sha256: 629365cde729a7b76b062fc218a109a84bbc4668ca0c92ab590ecccf969f824c
+        sha512: 255719cbd237e1501d431e60c69f2361625a19fb4ac21defff12e654f95c8e15f087f26964c3b2a6c877478f168a1d9b5599c74d39778cd741e1ccf7911559dd
     prepare:
       - |
         tar -xf glib.tar.xz --strip-components=1

--- a/guest-agents/qemu-guest-agent/pkg.yaml
+++ b/guest-agents/qemu-guest-agent/pkg.yaml
@@ -10,8 +10,8 @@ steps:
   - sources:
       - url: https://download.qemu.org/qemu-{{ .QEMU_VERSION }}.tar.xz
         destination: qemu.tar.xz
-        sha256: d0f4db0fbd151c0cf16f84aeb2a500f6e95009732546f44dafab8d2049bbb805
-        sha512: 6c120aaf52f15e79c32d883cc83df8fc83222d538ea6be9c19aaddfba0aef91479b5826bbc03e58688fba639cb24bc6f54e525ccc2404ed5d820766d11735210
+        sha256: a8c3f596aece96da3b00cafb74baafa0d14515eafb8ed1ee3f7f5c2d0ebf02b6
+        sha512: 58ed84f6fe6263d279356bc9193f96edf62cf3663fb151daa3f047d52329fe49cb91c2d45e09697e0469f4f5409be96403aec9572d4871ffa40848a786c21599
     prepare:
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml

--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -1,10 +1,10 @@
 # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=https://github.com/qemu/qemu.git
-QEMU_VERSION: 9.0.1
+QEMU_VERSION: 9.0.2
 # renovate: datasource=git-tags depName=https://gitlab.gnome.org/GNOME/glib.git
-GLIB_VERSION: 2.81.0
+GLIB_VERSION: 2.81.1
 # renovate: datasource=github-releases extractVersion=^pcre2-(?<version>.*)$ depName=PCRE2Project/pcre2
 PCRE2_VERSION: 10.42
 # renovate: datasource=git-tags depName=https://gitlab.com/xen-project/xen-guest-agent.git
 XEN_GUEST_AGENT_VERSION: 0.4.0
 # renovate: datasource=github-releases depName=siderolabs/talos-vmtoolsd
-TALOS_VMTOOLSD_VERSION: v0.5.1
+TALOS_VMTOOLSD_VERSION: v0.6.0

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -60,18 +60,20 @@ If production version is required, the schematic id should be updated to the pro
 ZFS: 2.2.4
 DRBD: 9.2.9
 gasket: 5815ee3
-Tailscale: 1.64.2
-ecr-credential-provider: 1.30.2
-qemu-guest-agent: 9.0.1
+Tailscale: 1.70.0
+ecr-credential-provider: 1.30.3
+qemu-guest-agent: 9.0.2
 mdadm: 4.3
 Intel microcode: 20240531
-Linux firmware: 20240513
-Spin: 1.5.0
-Gvisor: 20240624.0
+Linux firmware: 20240709
+Spin: 0.15.1
+Gvisor: 20240729.0
 Wasmedge: v0.4.0
-Kata Containers: 3.6.0
+Kata Containers: 3.3.0
 NVIDIA container toolkit: v1.15.0
 iscsi-tools: v0.1.5
+vmtoolsd: v0.6.0
+util-linux-tools: 2.40.2
 """
 
 

--- a/network/tailscale/pkg.yaml
+++ b/network/tailscale/pkg.yaml
@@ -12,8 +12,8 @@ steps:
     sources:
       - url: https://github.com/tailscale/tailscale/archive/refs/tags/v{{ .TAILSCALE_VERSION }}.tar.gz
         destination: tailscale.tar.gz
-        sha256: 9d34bd153c485dd0d88d3d76f187b5032046c0807a411ca97f38c8039a9ac659
-        sha512: d512e051cc05507f75de07c75ffa9f91b5a6c340facf3c15797950668570319d2dbbc9fa078788cff261c964ef5da64d9a4b7c6d46591c07b63131c2f39f3add
+        sha256: 8429728708f9694534489daa0a30af58be67f25742597940e7613793275c738f
+        sha512: 49fb2fccce8cfa6bce3f21d839a72bd7a78d4c8f0d867167e8984275878ad5c0b57b0de66bbde999a092c6e17567f66ea7fd31642cde5844b606e9562848d129
     prepare:
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml

--- a/network/vars.yaml
+++ b/network/vars.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-releases extractVersion=^v(?<version>.*)$ depName=tailscale/tailscale
-TAILSCALE_VERSION: 1.68.2
+TAILSCALE_VERSION: 1.70.0

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.mod
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.mod
@@ -2,4 +2,4 @@ module nvidia-container-runtime-wrapper
 
 go 1.22
 
-require golang.org/x/sys v0.21.0
+require golang.org/x/sys v0.23.0

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.sum
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
-golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
+golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
@@ -2,4 +2,4 @@ module nvidia-persistenced-wrapper
 
 go 1.22
 
-require golang.org/x/sys v0.21.0
+require golang.org/x/sys v0.23.0

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
-golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
+golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/storage/iscsi-tools/iscsid-wrapper/go.mod
+++ b/storage/iscsi-tools/iscsid-wrapper/go.mod
@@ -2,4 +2,4 @@ module iscsid-wrapper
 
 go 1.22
 
-require golang.org/x/sys v0.21.0
+require golang.org/x/sys v0.23.0

--- a/storage/iscsi-tools/iscsid-wrapper/go.sum
+++ b/storage/iscsi-tools/iscsid-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
-golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
+golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/tools/util-linux/pkg.yaml
+++ b/tools/util-linux/pkg.yaml
@@ -7,8 +7,8 @@ steps:
   - sources:
       - url: https://www.kernel.org/pub/linux/utils/util-linux/v{{ regexReplaceAll ".\\d+$" .UTIL_LINUX_VERSION "${1}" }}/util-linux-{{  regexReplaceAll "\\.0$" .UTIL_LINUX_VERSION "${1}" }}.tar.xz
         destination: util-linux.tar.xz
-        sha256: 59e676aa53ccb44b6c39f0ffe01a8fa274891c91bef1474752fad92461def24f
-        sha512: 58ec6eb41d4b6bfc544a80e95c71b5f3798ab4d2a9435d3ee9e5edd56f9b3f09bcb154bdd70e002dc018938937e2e946ae731dcda0f86b362fc43423689e41fc
+        sha256: d78b37a66f5922d70edf3bdfb01a6b33d34ed3c3cafd6628203b2a2b67c8e8b3
+        sha512: ffe20b915a518a150401d429b0338bc7022190e4ca0ef91a6d9eea345db8c1e11ad01784163b8fcf978506f3f5cad473f29d5d4ef93a4c66a5ae0ebd9fb0c8f2
     prepare:
       - |
         tar -xJf util-linux.tar.xz --strip-components=1


### PR DESCRIPTION
- run rekres
- siderolabs/pkgs to v1.8.0-alpha.0-41-ga97d58f
- golang.org/x/sys to v0.23.0
- linux firmware to 20240709
- google/gvisor to 20240729.0
- cloud-provider-aws to v1.30.3
- containerd-shim-spin to v0.15.1
- kata-containers/kata-containers to 3.7.0
- qemu to 9.0.2
- glib to 2.81.1
- siderolabs/talos-vmtoolsd to v0.6.0
- tailscale/tailscale to 1.70.0