### PR TITLE
fix(stargz-snapshotter): set default root path

### DIFF
--- a/container-runtime/stargz-snapshotter/stargz-snapshotter.yaml
+++ b/container-runtime/stargz-snapshotter/stargz-snapshotter.yaml
@@ -7,6 +7,7 @@ container:
   entrypoint: ./containerd-stargz-grpc
   args:
     - --address=/var/run/containerd-stargz-grpc/containerd-stargz-grpc.sock
+    - --root=/var/lib/containerd/io.containerd.snapshotter.v1.stargz
     - --log-level=debug
   security:
     rootfsPropagation: shared


### PR DESCRIPTION
### Description
This PR adds the default root path parameter to *stargz-snapshotter* extension as an argument: `--root`. It sets the path to */var/lib/containerd/io.containerd.snapshotter.v1.stargz* as it is a more common place to find it. The snapshotter default path is defined in [stargz-snapshotter/cmd/containerd-stargz-grpc/main.go#L66](https://github.com/containerd/stargz-snapshotter/blob/1dac5ef893199b3617e6a6cd118d75d71adc7df1/cmd/containerd-stargz-grpc/main.go#L66) and points to */var/lib/containerd-stargz-grpc*.

### Motivation
When trying the *stargz-snapshotter* extension I found some errors and seemed that the snapshotter wasn't working properly. I didn't copy the errors but they were something in the lines of:
- missing directory */var/lib/containerd/io.containerd.snapshotter.v1.stargz*.
- stargz-snapshotter plugin is not exporting its root directory.

### Investigation
Searching around I found some issues:
- https://github.com/siderolabs/extensions/issues/245
- https://github.com/containerd/stargz-snapshotter/issues/1349
- https://github.com/containerd/nydus-snapshotter/issues/288

The last of the issues listed above pointed me to the right track. There is a linked PR (https://github.com/containerd/containerd/pull/10127) where it is added to containerd the functionality to inform the remote snapshotter's root dir. Although it is advised to point it (if possible) to */var/lib/containerd/* for better compatibility. 

https://github.com/containerd/nydus-snapshotter/issues/288#issuecomment-2177354367
> But we'd better still set snapshotter's default root path to /var/lib/containerd/io.containerd.snapshotter.v1.nydus for the better compatibility.

### Testing
I've built the extension with the change, then built an installer image and upgraded a testing cluster with it. After it all the logs seemed normal. Also these logs from the CRI stream, leads me to think that cleanup of stale snapshots is working as expected:
```
{"level":"debug","msg":"schedule snapshotter cleanup","snapshotter":"stargz","time":"2024-08-15T15:17:49.143802230Z"}
{"key":"k8s.io/138/96b15cc0376d1abec916fb9fa9af3e6e83c7d0862ab82abd026fd309cee54723","level":"debug","msg":"removed snapshot","snapshotter":"stargz","time":"2024-08-15T15:17:49.147120976Z"}
```