### PR TITLE
feat: bump dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,9 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-11-02T15:47:10Z by kres 32170a7-dirty.
+# Generated on 2024-08-29T14:13:04Z by kres b5ca957.
 
 *
 !CHANGELOG.md
+!MAINTAINERS.md
 !README.md
 !pkg.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-06T13:24:11Z by kres 133368e.
+# Generated on 2024-08-29T14:13:04Z by kres b5ca957.
 
 name: default
 concurrency:
@@ -33,7 +33,7 @@ jobs:
       labels: ${{ steps.retrieve-pr-labels.outputs.result }}
     services:
       buildkitd:
-        image: moby/buildkit:v0.15.1
+        image: moby/buildkit:v0.15.2
         options: --privileged
         ports:
           - 1234:1234
@@ -143,7 +143,7 @@ jobs:
       - default
     services:
       buildkitd:
-        image: moby/buildkit:v0.15.1
+        image: moby/buildkit:v0.15.2
         options: --privileged
         ports:
           - 1234:1234

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-06T13:24:11Z by kres 133368e.
+# Generated on 2024-08-29T14:13:04Z by kres b5ca957.
 
 name: weekly
 concurrency:
@@ -16,7 +16,7 @@ jobs:
       - pkgs
     services:
       buildkitd:
-        image: moby/buildkit:v0.15.1
+        image: moby/buildkit:v0.15.2
         options: --privileged
         ports:
           - 1234:1234

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -59,7 +59,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.8.0-alpha.0-45-gaf6b4e6
+        defaultValue: v1.8.0-alpha.0-52-g4fd2541
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
   useBldrPkgTagResolver: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-06T11:36:28Z by kres 2fded2b.
+# Generated on 2024-08-29T14:13:04Z by kres b5ca957.
 
 # common variables
 
@@ -48,7 +48,7 @@ COMMON_ARGS += --build-arg=PKGS_PREFIX="$(PKGS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.8.0-alpha.0-45-gaf6b4e6
+PKGS ?= v1.8.0-alpha.0-52-g4fd2541
 PKGS_PREFIX ?= ghcr.io/siderolabs
 
 # targets defines all the available targets

--- a/Pkgfile
+++ b/Pkgfile
@@ -3,8 +3,8 @@
 format: v1alpha2
 
 vars:
-  LINUX_FIRMWARE_VERSION: "20240709" # update this when updating PKGS_VERSION in Makefile
-  DRBD_DRIVER_VERSION: 9.2.9 # update this when updating PKGS_VERSION in Makefile
+  LINUX_FIRMWARE_VERSION: "20240811" # update this when updating PKGS_VERSION in Makefile
+  DRBD_DRIVER_VERSION: 9.2.11 # update this when updating PKGS_VERSION in Makefile
   ZFS_DRIVER_VERSION: 2.2.4 # update this when updating PKGS_VERSION in Makefile
   UTIL_LINUX_VERSION: 2.40.2 # update this when updating PKGS_VERSION in Makefile
 

--- a/container-runtime/crun/pkg.yaml
+++ b/container-runtime/crun/pkg.yaml
@@ -8,13 +8,13 @@ steps:
       # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
       - url: https://github.com/containers/crun/releases/download/{{ .CRUN_VERSION }}/crun-{{ .CRUN_VERSION }}-linux-arm64-disable-systemd
         destination: crun
-        sha256: 0151e6ea9a7d36de94651347b69b2937c8e657a663afb55180ade3153d5d4064
-        sha512: 889e347890ed0b9ecd568830195ebf94d4cd63757ab37db622546c640df292a5816e91669054158ca3db816bd05ce2b6d37f734e6a30f81c978fd16cbfdc1e3e
+        sha256: c8b3f77f999bdaea558ab6a13f5d5d9b6d979432cf685db604de1f98dfd99c54
+        sha512: 6ec6a3a12af6968358cabc4c67f98c69d6c9f883da8ed0526df87b0818803e4082ca9da0b4956b101f97e065c7335865c0e16a37ea1c602029c41762d460ab9a
       # {{ else }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
       - url: https://github.com/containers/crun/releases/download/{{ .CRUN_VERSION }}/crun-{{ .CRUN_VERSION }}-linux-amd64-disable-systemd
         destination: crun
-        sha256: 96f27bb57ba3d8441e76e8d3ac6af98d37a9907e6a0ffbcdbc19d72c652c48ae
-        sha512: e914ba72e9f6b1cc407585076321166c822cf49e0849e602e2f1ed1d4e355e589a39c15b3770ef43b7b9fccb9985c822b922277b204e04005091c8ce3917d767
+        sha256: 08ced901166ab86fd517f91fa05c90b92d209adb61b5ff7c7ab73e0b2c8275e1
+        sha512: 93c90d7a572246bd878596c69370638bf09b8eea227624d900ab2715fafddfba238a8fc8fc452324e2eb57adb2467687ab16c14816142369ce56b8cc40b0b042
     # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
     prepare:
       - |

--- a/container-runtime/ecr-credential-provider/pkg.yaml
+++ b/container-runtime/ecr-credential-provider/pkg.yaml
@@ -7,8 +7,8 @@ steps:
   - sources:
       - url: https://github.com/kubernetes/cloud-provider-aws/archive/refs/tags/{{ .VERSION }}.tar.gz
         destination: cloud-provider-aws.tar.gz
-        sha256: 53ad64af7118449a4d732f82df7b3aeb4eb1551aabf48a213596bd2e662376e2
-        sha512: aa351cd531e452dd4ccead4a591a9161a25737ada93a7317c5c181c3d4fe55b279e94b686d8c03665ebee01191129a52b01c9dabfba7075c5e9bde52e6a341c8
+        sha256: 139f9c54ebc89af5c868b1a4fe36419f0216eebe148079c7d38dcba0a3f96824
+        sha512: 962973013984a802853311182e1cfd1eabb1bcdf164000f607aeb2631ac98a0b4fd5ba1f7aff08491040979bd2321bcd5debd567c9aa74889b09d7599bc4dcfd
     env:
       GOPATH: /go
     cachePaths:

--- a/container-runtime/vars.yaml
+++ b/container-runtime/vars.yaml
@@ -3,7 +3,7 @@ GVISOR_VERSION: 20240729.0
 # renovate: datasource=github-releases depName=containerd/stargz-snapshotter
 STARGZ_SNAPSHOTTER_VERSION: v0.15.1
 # renovate: datasource=github-releases depName=kubernetes/cloud-provider-aws
-CLOUD_PROVIDER_AWS_VERSION: v1.30.3
+CLOUD_PROVIDER_AWS_VERSION: v1.31.0
 # renovate: datasource=git-tags extractVersion=^containerd-shim-wasmedge\/(?<version>.*)$ depName=https://github.com/containerd/runwasi.git
 WASMEDGE_VERSION: v0.4.0
 # renovate: datasource=git-tags depName=https://github.com/spinkube/containerd-shim-spin.git
@@ -11,4 +11,4 @@ SPIN_VERSION: v0.15.1
 # renovate: datasource=github-releases depName=kata-containers/kata-containers
 KATA_CONTAINERS_VERSION: 3.3.0
 # renovate: datasource=github-releases depName=containers/crun
-CRUN_VERSION: 1.16
+CRUN_VERSION: 1.16.1

--- a/firmware/intel-ucode/pkg.yaml
+++ b/firmware/intel-ucode/pkg.yaml
@@ -7,8 +7,8 @@ steps:
   - sources:
       - url: https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/refs/tags/microcode-{{ .INTEL_UCODE_VERSION }}.tar.gz
         destination: intel-ucode.tar.gz
-        sha256: c29eb35fdbd39e3ed8587e6f0b1275cc03265f230c2fcaf88e2a1556451e773f
-        sha512: fb9d772491f279ebb691248e4a665da45c986ca7b4668ecf311c5fcb91a42400f7a5b35e8bfc31ceb1c9d598e753c817359900e3fa316d825f8ecec21ec63cfe
+        sha256: f46cfe1d8be8d3c2c5a0fb63fc4d48c7dd1444f34346f0e42ad92c706cb90e79
+        sha512: ba1fa7d9bed7d90756ea959f5878afca0deacc9b1e932a936a15d74a411b7efb6103a4af75dc3731d9cbb2e464439ce9a7d448f75bc6f38b616907ff6dec6ee3
     prepare:
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml

--- a/firmware/vars.yaml
+++ b/firmware/vars.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-releases extractVersion=^microcode-(?<version>.*)$ depName=intel/Intel-Linux-Processor-Microcode-Data-Files
-INTEL_UCODE_VERSION: 20240531
+INTEL_UCODE_VERSION: 20240813

--- a/guest-agents/qemu-guest-agent/glib/pkg.yaml
+++ b/guest-agents/qemu-guest-agent/glib/pkg.yaml
@@ -30,6 +30,7 @@ steps:
           --prefix=/usr \
           -Ddefault_library=both \
           -Dlibelf=disabled \
+          -Dselinux=disabled \
           _build
 
         ninja -C _build

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-11-02T15:47:10Z by kres 32170a7-dirty.
+# Generated on 2024-08-29T14:13:04Z by kres b5ca957.
 
 set -e
 
@@ -44,7 +44,90 @@ function commit {
     exit 1
   fi
 
+  if is_on_main_branch; then
+    update_license_files
+  fi
+
   git commit -s -m "release($1): prepare release" -m "This is the official $1 release."
+}
+
+function is_on_main_branch {
+  main_remotes=("upstream" "origin")
+  branch_names=("main" "master")
+  current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+  echo "Check current branch: $current_branch"
+
+  for remote in "${main_remotes[@]}"; do
+    echo "Fetch remote $remote..."
+
+    if ! git fetch --quiet "$remote" &>/dev/null; then
+      echo "Failed to fetch $remote, skip..."
+
+      continue
+    fi
+
+    for branch_name in "${branch_names[@]}"; do
+      if ! git rev-parse --verify "$branch_name" &>/dev/null; then
+        echo "Branch $branch_name does not exist, skip..."
+
+        continue
+      fi
+
+      echo "Branch $remote/$branch_name exists, comparing..."
+
+      merge_base=$(git merge-base "$current_branch" "$remote/$branch_name")
+      latest_main=$(git rev-parse "$remote/$branch_name")
+
+      if [ "$merge_base" = "$latest_main" ]; then
+        echo "Current branch is up-to-date with $remote/$branch_name"
+
+        return 0
+      else
+        echo "Current branch is not on $remote/$branch_name"
+
+        return 1
+      fi
+    done
+  done
+
+  echo "No main or master branch found on any remote"
+
+  return 1
+}
+
+function update_license_files {
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  parent_dir="$(dirname "$script_dir")"
+  current_year=$(date +"%Y")
+  change_date=$(date -v+4y +"%Y-%m-%d" 2>/dev/null || date -d "+4 years" +"%Y-%m-%d" 2>/dev/null || date --date="+4 years" +"%Y-%m-%d")
+
+  # Find LICENSE and .kres.yaml files recursively in the parent directory (project root)
+  find "$parent_dir" \( -name "LICENSE" -o -name ".kres.yaml" \) -type f | while read -r file; do
+    temp_file="${file}.tmp"
+
+    if [[ $file == *"LICENSE" ]]; then
+      if grep -q "^Business Source License" "$file"; then
+        sed -e "s/The Licensed Work is (c) [0-9]\{4\}/The Licensed Work is (c) $current_year/" \
+          -e "s/Change Date:          [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}/Change Date:          $change_date/" \
+          "$file" >"$temp_file"
+      else
+        continue # Not a Business Source License file
+      fi
+    elif [[ $file == *".kres.yaml" ]]; then
+      sed -E 's/^([[:space:]]*)ChangeDate:.*$/\1ChangeDate: "'"$change_date"'"/' "$file" >"$temp_file"
+    fi
+
+    # Check if the file has changed
+    if ! cmp -s "$file" "$temp_file"; then
+      mv "$temp_file" "$file"
+      echo "Updated: $file"
+      git add "$file"
+    else
+      echo "No changes: $file"
+      rm "$temp_file"
+    fi
+  done
 }
 
 if declare -f "$1" > /dev/null
@@ -55,7 +138,7 @@ then
 else
   cat <<EOF
 Usage:
-  commit:        Create the official release commit message.
+  commit:        Create the official release commit message (updates BUSL license dates if there is any).
   cherry-pick:   Cherry-pick a commit into a release branch.
   changelog:     Update the specified CHANGELOG.
   release-notes: Create release notes for GitHub release.

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -58,14 +58,14 @@ If production version is required, the schematic id should be updated to the pro
     title = "Component Updates"
     description = """
 ZFS: 2.2.4
-DRBD: 9.2.9
+DRBD: 9.2.11
 gasket: 5815ee3
 Tailscale: 1.70.0
-ecr-credential-provider: 1.30.3
+ecr-credential-provider: 1.31.0
 qemu-guest-agent: 9.0.2
 mdadm: 4.3
-Intel microcode: 20240531
-Linux firmware: 20240709
+Intel microcode: 20240813
+Linux firmware: 20240811
 Spin: 0.15.1
 Gvisor: 20240729.0
 Wasmedge: v0.4.0

--- a/network/tailscale/pkg.yaml
+++ b/network/tailscale/pkg.yaml
@@ -12,8 +12,8 @@ steps:
     sources:
       - url: https://github.com/tailscale/tailscale/archive/refs/tags/v{{ .TAILSCALE_VERSION }}.tar.gz
         destination: tailscale.tar.gz
-        sha256: 8429728708f9694534489daa0a30af58be67f25742597940e7613793275c738f
-        sha512: 49fb2fccce8cfa6bce3f21d839a72bd7a78d4c8f0d867167e8984275878ad5c0b57b0de66bbde999a092c6e17567f66ea7fd31642cde5844b606e9562848d129
+        sha256: 21b529e85144f526b61e0998c8b7885d53f17cba21252e5c7252c4014f5f507b
+        sha512: 9ee23d78ce305232184489df5caf0bb22d43ab5be99327801ae077de5aa720e09d9ca43c1585a62d2dc1b5099304bfabf82ca9d0c17a250eae66ffc5ca960713
     prepare:
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml

--- a/network/vars.yaml
+++ b/network/vars.yaml
@@ -1,2 +1,2 @@
 # renovate: datasource=github-releases extractVersion=^v(?<version>.*)$ depName=tailscale/tailscale
-TAILSCALE_VERSION: 1.70.0
+TAILSCALE_VERSION: 1.72.1

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.mod
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.mod
@@ -2,4 +2,4 @@ module nvidia-container-runtime-wrapper
 
 go 1.22
 
-require golang.org/x/sys v0.23.0
+require golang.org/x/sys v0.24.0

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.sum
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
-golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
+golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.mod
@@ -2,4 +2,4 @@ module nvidia-persistenced-wrapper
 
 go 1.22
 
-require golang.org/x/sys v0.23.0
+require golang.org/x/sys v0.24.0

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-persistenced-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
-golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
+golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/nvidia-gpu/vars.yaml
+++ b/nvidia-gpu/vars.yaml
@@ -10,7 +10,7 @@ CONTAINER_TOOLKIT_REF: a470818ba7d9166be282cd0039dd2fc9b0a34d73
 LIBNVIDIA_CONTAINER_VERSION: v1.16.1
 LIBNVIDIA_CONTAINER_REF: 4c2494f16573b585788a42e9c7bee76ecd48c73d
 # renovate: datasource=docker versioning=docker depName=cgr.dev/chainguard/wolfi-base
-WOLFI_BASE_REF: sha256:bf0547b7d8d03e4f43e3e2b91630af5dc560bd91d09b8286148da8ffebd2092a
+WOLFI_BASE_REF: sha256:72c8bfed3266b2780243b144dc5151150015baf5a739edbbde53d154574f1607
 # renovate: datasource=git-tags extractVersion=^glibc-(?<version>.*)$ depName=https://sourceware.org/git/glibc.git
 GLIBC_VERSION: 2.40
 # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=seccomp/libseccomp

--- a/storage/iscsi-tools/iscsid-wrapper/go.mod
+++ b/storage/iscsi-tools/iscsid-wrapper/go.mod
@@ -2,4 +2,4 @@ module iscsid-wrapper
 
 go 1.22
 
-require golang.org/x/sys v0.23.0
+require golang.org/x/sys v0.24.0

--- a/storage/iscsi-tools/iscsid-wrapper/go.sum
+++ b/storage/iscsi-tools/iscsid-wrapper/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
-golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
+golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
Rekres, bump Go deps.

| Package | Update | Change |
|---|---|---|
| [containers/crun](https://togithub.com/containers/crun) | patch | `1.16` -> `1.16.1` |
| [intel/Intel-Linux-Processor-Microcode-Data-Files](https://togithub.com/intel/Intel-Linux-Processor-Microcode-Data-Files) | minor | `20240531` -> `20240813` |
| [kubernetes/cloud-provider-aws](https://togithub.com/kubernetes/cloud-provider-aws) | minor | `v1.30.3` -> `v1.31.0` |
| [tailscale/tailscale](https://togithub.com/tailscale/tailscale) | minor | `1.70.0` -> `1.72.1` |
| cgr.dev/chainguard/wolfi-base |  digest | `bf0547b` -> `72c8bfe` |
