### PR TITLE
feat: update depenendencies

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -60,7 +60,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.8.0-alpha.0-54-g4ce5bc6
+        defaultValue: v1.8.0
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
   useBldrPkgTagResolver: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-30T11:52:57Z by kres b5ca957.
+# Generated on 2024-09-06T11:07:46Z by kres 8be5fa7.
 
 # common variables
 
@@ -48,7 +48,7 @@ COMMON_ARGS += --build-arg=PKGS_PREFIX="$(PKGS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.8.0-alpha.0-54-g4ce5bc6
+PKGS ?= v1.8.0
 PKGS_PREFIX ?= ghcr.io/siderolabs
 
 # targets defines all the available targets

--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@ format: v1alpha2
 vars:
   LINUX_FIRMWARE_VERSION: "20240811" # update this when updating PKGS_VERSION in Makefile
   DRBD_DRIVER_VERSION: 9.2.11 # update this when updating PKGS_VERSION in Makefile
-  ZFS_DRIVER_VERSION: 2.2.4 # update this when updating PKGS_VERSION in Makefile
+  ZFS_DRIVER_VERSION: 2.2.6 # update this when updating PKGS_VERSION in Makefile
   UTIL_LINUX_VERSION: 2.40.2 # update this when updating PKGS_VERSION in Makefile
 
   # renovate: datasource=git-tags extractVersion=^libtiprc-(?<version>.*)$ depName=git://linux-nfs.org/~steved/libtirpc

--- a/container-runtime/gvisor/pkg.yaml
+++ b/container-runtime/gvisor/pkg.yaml
@@ -7,10 +7,10 @@ steps:
   - sources:
       # gvisor repo 'master' branch is Bazel-bazed, so we need to find matching commit in the "go" branch
       # find the go-branch specific merge commit ("Merge release-... (automated)") which has the release-tagged commit as a parent
-      - url: https://github.com/google/gvisor/archive/3f38cb19ba373b027f5220450591daa3ab767145.tar.gz
+      - url: https://github.com/google/gvisor/archive/9f3309e5b12177159bc961e560ecfc982d0a4a07.tar.gz
         destination: gvisor.tar.gz
-        sha256: ea4429edfa1c8ac811236557ca87f935de189d6108b0743261f907788b0b7257
-        sha512: 6eebda6c6a42235d678587501003cd5a34490ac4c2bb594c6c51bc3c17f87d49100d3892d82eaf2cdebb29c2b5902574ab82130cabc145bfdfca75c689b7d247
+        sha256: 4c271d688f9244b7079e78c86e23a5f21063cef76c5c7c7a8f261ff8e2f4b4fa
+        sha512: 04ddd8a834dfa2c46d34977be7ad07abf1ed7fbc70446dcbdb687c9e41258f2f3a744f7526e5cc693026d8a58143af11a8f4c2de572fa64496a62d3019d54a51
     env:
       GOPATH: /go
     cachePaths:

--- a/container-runtime/vars.yaml
+++ b/container-runtime/vars.yaml
@@ -1,5 +1,5 @@
 # renovate: datasource=github-tags extractVersion=^release-(?<version>.*)$ depName=google/gvisor
-GVISOR_VERSION: 20240729.0
+GVISOR_VERSION: 20240826.0
 # renovate: datasource=github-releases depName=containerd/stargz-snapshotter
 STARGZ_SNAPSHOTTER_VERSION: v0.15.1
 # renovate: datasource=github-releases depName=kubernetes/cloud-provider-aws

--- a/guest-agents/qemu-guest-agent/glib/pkg.yaml
+++ b/guest-agents/qemu-guest-agent/glib/pkg.yaml
@@ -9,8 +9,8 @@ steps:
   - sources:
       - url: https://download.gnome.org/sources/glib/{{ regexReplaceAll ".\\d+$" .GLIB_VERSION "${1}" }}/glib-{{ .GLIB_VERSION }}.tar.xz
         destination: glib.tar.xz
-        sha256: 629365cde729a7b76b062fc218a109a84bbc4668ca0c92ab590ecccf969f824c
-        sha512: 255719cbd237e1501d431e60c69f2361625a19fb4ac21defff12e654f95c8e15f087f26964c3b2a6c877478f168a1d9b5599c74d39778cd741e1ccf7911559dd
+        sha256: f4c82ada51366bddace49d7ba54b33b4e4d6067afa3008e4847f41cb9b5c38d3
+        sha512: 7ce4dbc2b80fea1dca722bea02b1c35404108747b94c296760469b5416fc5ca737fc29c56a091120e5457a732656761424da614f3a626eb79b80b145507deb00
     prepare:
       - |
         tar -xf glib.tar.xz --strip-components=1

--- a/guest-agents/qemu-guest-agent/pkg.yaml
+++ b/guest-agents/qemu-guest-agent/pkg.yaml
@@ -10,8 +10,8 @@ steps:
   - sources:
       - url: https://download.qemu.org/qemu-{{ .QEMU_VERSION }}.tar.xz
         destination: qemu.tar.xz
-        sha256: a8c3f596aece96da3b00cafb74baafa0d14515eafb8ed1ee3f7f5c2d0ebf02b6
-        sha512: 58ed84f6fe6263d279356bc9193f96edf62cf3663fb151daa3f047d52329fe49cb91c2d45e09697e0469f4f5409be96403aec9572d4871ffa40848a786c21599
+        sha256: 816b7022a8ba7c2ac30e2e0cf973e826f6bcc8505339603212c5ede8e94d7834
+        sha512: bf61d65e37945fa8ee8640712c719ace05164d86e6df700b98bdc5f79e0a8d5e8f85bd48e726edb62b2419db20673f63ec8b63a60393a914b09cb365621b35e2
     prepare:
       - |
         sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml

--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -1,7 +1,7 @@
 # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=https://github.com/qemu/qemu.git
-QEMU_VERSION: 9.0.2
+QEMU_VERSION: 9.1.0
 # renovate: datasource=git-tags depName=https://gitlab.gnome.org/GNOME/glib.git
-GLIB_VERSION: 2.81.1
+GLIB_VERSION: 2.82.0
 # renovate: datasource=github-releases extractVersion=^pcre2-(?<version>.*)$ depName=PCRE2Project/pcre2
 PCRE2_VERSION: 10.42
 # renovate: datasource=git-tags depName=https://gitlab.com/xen-project/xen-guest-agent.git

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -57,12 +57,12 @@ If production version is required, the schematic id should be updated to the pro
 [notes.updates]
     title = "Component Updates"
     description = """
-ZFS: 2.2.4
+ZFS: 2.2.6
 DRBD: 9.2.11
 gasket: 5815ee3
 Tailscale: 1.70.0
 ecr-credential-provider: 1.31.0
-qemu-guest-agent: 9.0.2
+qemu-guest-agent: 9.1.0
 mdadm: 4.3
 Intel microcode: 20240813
 Linux firmware: 20240811

--- a/storage/zfs/zfs-tools/pkg.yaml
+++ b/storage/zfs/zfs-tools/pkg.yaml
@@ -11,8 +11,8 @@ steps:
   - sources:
       - url: https://github.com/openzfs/zfs/releases/download/zfs-{{ .ZFS_DRIVER_VERSION }}/zfs-{{ .ZFS_DRIVER_VERSION }}.tar.gz
         destination: zfs.tar.gz
-        sha256: 9790905f7683d41759418e1ef3432828c31116654ff040e91356ff1c21c31ec0
-        sha512: 1d17e30573d594fb5c9ea77cde104616dca362fed7530296816d1b55173594f66170fcfb23ab57c27074f85b79d3eb557b4ee9a1c420e507b2434a7902d8dcc1
+        sha256: c92e02103ac5dd77bf01d7209eabdca55c7b3356aa747bb2357ec4222652a2a7
+        sha512: c217a3397b67d7239bc30bc492d58fff96bb29c9cf73e390d1787a4fb787cb297557e594a926453fed11faaab80363d40853af271f8ee18ce9a317dfde4c6745
     env:
       ARCH: {{ if eq .ARCH "aarch64"}}arm64{{ else if eq .ARCH "x86_64" }}x86_64{{ else }}unsupported{{ end }}
     prepare:


### PR DESCRIPTION
Update `pkgs` to Talos 1.8.0 version.

ZFS to 2.2.6 via pkgs.

| Package | Update | Change |
|---|---|---|
| [google/gvisor](https://redirect.github.com/google/gvisor) | minor | `20240729.0` -> `20240826.0` |
| [https://github.com/qemu/qemu.git](https://redirect.github.com/qemu/qemu) | minor | `9.0.2` -> `9.1.0` |
| [https://gitlab.gnome.org/GNOME/glib.git](https://gitlab.gnome.org/GNOME/glib) | minor | `2.81.1` -> `2.82.0` |
