### PR TITLE
feat: add extension `metal-agent`

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -26,6 +26,7 @@ spec:
     - lldpd
     - mdadm
     - mei
+    - metal-agent
     - nut-client
     - nvidia-container-toolkit-lts
     - nvidia-container-toolkit-production

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -33,6 +33,7 @@ If the field is marked as `Needs Maintainer`, it means that the package is curre
 | lldpd                                     | Nokia (Niklas Wik)   | [salkin](https://github.com/salkin)                                  |
 | mdadm                                     | Serge Logvinov       | [sergelogvinov](https://github.com/sergelogvinov)                    |
 | mei                                       | Nick Meyer           | [e3b0c442](https://github.com/e3b0c442)                              |
+| metal-agent                               | Sidero Labs          | NA                                                                   |
 | nut-client                                | Sidero Labs          | NA                                                                   |
 | nvidia-container-toolkit-lts              | Sidero Labs          | NA                                                                   |
 | nivida-container-toolkit-production       | Sidero Labs          | NA                                                                   |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-10-23T15:05:59Z by kres 6d3cad4.
+# Generated on 2024-10-30T12:38:48Z by kres 6d3cad4.
 
 # common variables
 
@@ -77,6 +77,7 @@ TARGETS += kata-containers
 TARGETS += lldpd
 TARGETS += mdadm
 TARGETS += mei
+TARGETS += metal-agent
 TARGETS += nut-client
 TARGETS += nvidia-container-toolkit-lts
 TARGETS += nvidia-container-toolkit-production

--- a/guest-agents/metal-agent/README.md
+++ b/guest-agents/metal-agent/README.md
@@ -1,0 +1,11 @@
+# metal-agent
+
+Adds [talos-metal-agent](https://github.com/siderolabs/talos-metal-agent) as a system extension.
+
+## Installation
+
+See [Installing Extensions](https://github.com/siderolabs/extensions#installing-extensions).
+
+## Configuration
+
+This extension requires no configuration.

--- a/guest-agents/metal-agent/manifest.yaml
+++ b/guest-agents/metal-agent/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: metal-agent
+  version: "$VERSION"
+  author: Sidero Labs
+  description: |
+    This system extension provides talos-metal-agent
+  compatibility:
+    talos:
+      version: ">= 1.9.0-alpha.0"

--- a/guest-agents/metal-agent/metal-agent.yaml
+++ b/guest-agents/metal-agent/metal-agent.yaml
@@ -1,0 +1,24 @@
+name: metal-agent
+container:
+  entrypoint: ./talos-metal-agent
+  args: []
+  mounts:
+    - source: /system/run/machined/machine.sock
+      destination: /system/run/machined/machine.sock
+      type: bind
+      options:
+        - rshared
+        - rbind
+    - source: /dev
+      destination: /dev
+      type: bind
+      options:
+        - rshared
+        - rbind
+        - rw
+depends:
+  - path: /system/run/machined/machine.sock
+  - network:
+      - addresses
+restart: always
+logToConsole: true

--- a/guest-agents/metal-agent/pkg.yaml
+++ b/guest-agents/metal-agent/pkg.yaml
@@ -1,0 +1,50 @@
+name: metal-agent
+variant: scratch
+dependencies:
+  - stage: base
+
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/fhs:{{ .BUILD_ARG_PKGS }}"
+    from: /
+    to: /rootfs/usr/local/lib/containers/metal-agent
+
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/ca-certificates:{{ .BUILD_ARG_PKGS }}"
+    from: /
+    to: /rootfs/usr/local/lib/containers/metal-agent
+
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/openssl:{{ .BUILD_ARG_PKGS }}"
+    from: /
+    to: /rootfs/usr/local/lib/containers/metal-agent
+
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/musl:{{ .BUILD_ARG_PKGS }}"
+    from: /
+    to: /rootfs/usr/local/lib/containers/metal-agent
+
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/ipmitool:{{ .BUILD_ARG_PKGS }}"
+    from: /
+    to: /rootfs/usr/local/lib/containers/metal-agent
+
+  - image: "{{ .IMAGE_PREFIX }}/talos-metal-agent:{{ .VERSION }}"
+    from: /
+    to: /rootfs/usr/local/lib/containers/metal-agent
+steps:
+  - prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+    install:
+      - |
+        mkdir -p /rootfs/usr/local/etc/containers
+
+        cp /pkg/metal-agent.yaml /rootfs/usr/local/etc/containers/
+      - |
+        touch /rootfs/usr/local/etc/is-metal-agent
+    test:
+      - |
+        mkdir -p /extensions-validator-rootfs
+        cp -r /rootfs/ /extensions-validator-rootfs/rootfs
+        cp /pkg/manifest.yaml /extensions-validator-rootfs/manifest.yaml
+        /extensions-validator validate --rootfs=/extensions-validator-rootfs --pkg-name="${PKG_NAME}"
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/guest-agents/metal-agent/vars.yaml
+++ b/guest-agents/metal-agent/vars.yaml
@@ -1,0 +1,2 @@
+VERSION: "{{ .TALOS_METAL_AGENT_VERSION }}"
+IMAGE_PREFIX: ghcr.io/siderolabs

--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -8,3 +8,5 @@ PCRE2_VERSION: 10.42
 XEN_GUEST_AGENT_VERSION: 0.4.0
 # renovate: datasource=github-releases depName=siderolabs/talos-vmtoolsd
 TALOS_VMTOOLSD_VERSION: v0.6.0
+# renovate: datasource=github-releases depName=siderolabs/talos-metal-agent
+TALOS_METAL_AGENT_VERSION: v0.1.0-alpha.0


### PR DESCRIPTION
Add the new metal agent extension to run Talos in metal agent mode.

Related to https://github.com/siderolabs/talos/pull/9501.

Depends on https://github.com/siderolabs/talos-metal-agent/pull/1 and the initial release (`v0.1.0`) of the agent.