### PR TITLE
chore: update wolfi-base

### DIFF
--- a/misc/glibc/vars.yaml
+++ b/misc/glibc/vars.yaml
@@ -1,4 +1,4 @@
 # renovate: datasource=docker versioning=docker depName=cgr.dev/chainguard/wolfi-base
-WOLFI_BASE_REF: sha256:72c8bfed3266b2780243b144dc5151150015baf5a739edbbde53d154574f1607
+WOLFI_BASE_REF: sha256:0c1bf69476e3ca3d4763ca3067773e8796a1faecd56678a3b748cd90cfb9b9a5
 
 VERSION: {{ .GLIBC_VERSION }}

--- a/nvidia-gpu/vars.yaml
+++ b/nvidia-gpu/vars.yaml
@@ -10,7 +10,7 @@ CONTAINER_TOOLKIT_REF: a470818ba7d9166be282cd0039dd2fc9b0a34d73
 LIBNVIDIA_CONTAINER_VERSION: v1.16.1
 LIBNVIDIA_CONTAINER_REF: 4c2494f16573b585788a42e9c7bee76ecd48c73d
 # renovate: datasource=docker versioning=docker depName=cgr.dev/chainguard/wolfi-base
-WOLFI_BASE_REF: sha256:72c8bfed3266b2780243b144dc5151150015baf5a739edbbde53d154574f1607
+WOLFI_BASE_REF: sha256:0c1bf69476e3ca3d4763ca3067773e8796a1faecd56678a3b748cd90cfb9b9a5
 # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=seccomp/libseccomp
 LIBSECCOMP_VERSION: 2.5.5
 # renovate: datasource=git-tags extractVersion=^libcap-(?<version>.*)$ depName=git://git.kernel.org/pub/scm/libs/libcap/libcap.git


### PR DESCRIPTION
Fix the glibc extension build by updating wolfi-base. The wolfi repo has a new build of python3 that depends on an updated libssl from the base image.

The content hash was retrieved from cgr.dev/chainguard/wolfi-base:latest on 2024-11-01T17:50:00-07:00.