### PR TITLE
feat(fabricmanager): add all topology files

### DIFF
--- a/nvidia-gpu/nvidia-fabricmanager/production/lts/pkg.yaml
+++ b/nvidia-gpu/nvidia-fabricmanager/production/lts/pkg.yaml
@@ -35,8 +35,7 @@ steps:
         cp bin/nv-fabricmanager /rootfs/usr/local/bin/
         cp bin/nvswitch-audit /rootfs/usr/local/bin/
 
-        cp share/nvidia/nvswitch/dgx2_hgx2_topology /rootfs/usr/local/share/nvidia/nvswitch/
-        cp share/nvidia/nvswitch/dgxa100_hgxa100_topology /rootfs/usr/local/share/nvidia/nvswitch/
+        cp share/nvidia/nvswitch/* /rootfs/usr/local/share/nvidia/nvswitch/
 
         cp etc/fabricmanager.cfg  /rootfs/usr/local/share/nvidia/nvswitch/
 


### PR DESCRIPTION
Include all topology files from the Nvidia fabric manager release.

This will help ensure compatibility with newer GPU architectures, and fixes the issue of not including files required for H100 and H200