### PR TITLE
bump vmtoolsd version to v0.6.1

### DIFF
--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -7,6 +7,6 @@ PCRE2_VERSION: 10.42
 # renovate: datasource=git-tags depName=https://gitlab.com/xen-project/xen-guest-agent.git
 XEN_GUEST_AGENT_VERSION: 0.4.0
 # renovate: datasource=github-releases depName=siderolabs/talos-vmtoolsd
-TALOS_VMTOOLSD_VERSION: v0.6.0
+TALOS_VMTOOLSD_VERSION: v0.6.1
 # renovate: datasource=github-releases depName=siderolabs/talos-metal-agent
 TALOS_METAL_AGENT_VERSION: v0.1.0-alpha.0

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -33,6 +33,7 @@ ecr-credential-provider: 1.31.1
 Intel microcode: 20241029
 NVIDIA LTS: 535.216.01
 NVIDIA Production: 550.127.05
+vmtoolsd-guest-agent: v0.6.1
 """
 
 [make_deps]


### PR DESCRIPTION
Bump the version to 0.6.1 to add the latest bugfix version of vmtoolsd to Talos extensions.
[https://github.com/siderolabs/talos-vmtoolsd/releases/tag/v0.6.1](https://github.com/siderolabs/talos-vmtoolsd/releases/tag/v0.6.1)