### PR TITLE
chore: bump metal-agent

### DIFF
--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -9,4 +9,4 @@ XEN_GUEST_AGENT_VERSION: 0.4.0
 # renovate: datasource=github-releases depName=siderolabs/talos-vmtoolsd
 TALOS_VMTOOLSD_VERSION: v0.6.1
 # renovate: datasource=github-releases depName=siderolabs/talos-metal-agent
-TALOS_METAL_AGENT_VERSION: v0.1.0-alpha.0
+TALOS_METAL_AGENT_VERSION: v0.1.0-alpha.2


### PR DESCRIPTION
Bump it to v0.1.0-alpha.2: https://github.com/siderolabs/talos-metal-agent/releases/tag/v0.1.0-alpha.2