### PR TITLE
feat: set PATH variable in metal-agent

### DIFF
--- a/guest-agents/metal-agent/metal-agent.yaml
+++ b/guest-agents/metal-agent/metal-agent.yaml
@@ -2,6 +2,8 @@ name: metal-agent
 container:
   entrypoint: ./talos-metal-agent
   args: []
+  environment:
+    - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
   mounts:
     - source: /system/run/machined/machine.sock
       destination: /system/run/machined/machine.sock


### PR DESCRIPTION
Set the common paths in the PATH variable, so that we don't need to hardcode the `ipmitool` path.