### PR TITLE
chore: bump metal agent version

### DIFF
--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -9,4 +9,4 @@ XEN_GUEST_AGENT_VERSION: 0.4.0
 # renovate: datasource=github-releases depName=siderolabs/talos-vmtoolsd
 TALOS_VMTOOLSD_VERSION: v0.6.1
 # renovate: datasource=github-releases depName=siderolabs/talos-metal-agent
-TALOS_METAL_AGENT_VERSION: v0.1.0-alpha.2
+TALOS_METAL_AGENT_VERSION: v0.1.0-beta.0


### PR DESCRIPTION
Bump metal agent version.

https://github.com/siderolabs/talos-metal-agent/releases/tag/v0.1.0-beta.0