### PR TITLE
fix: used cloudflared binaries instead of building from sources

### DIFF
--- a/network/cloudflared/manifest.yaml
+++ b/network/cloudflared/manifest.yaml
@@ -1,7 +1,7 @@
 version: v1alpha1
 metadata:
   name: cloudflared
-  version: "$VERSION"
+  version: "$CLOUDFLARED_VERSION"
   author: Maxime Narbaud
   description: |
     Cloudflare Tunnel securely connects resources to Cloudflare without a public IP.

--- a/network/cloudflared/pkg.yaml
+++ b/network/cloudflared/pkg.yaml
@@ -5,30 +5,25 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://github.com/cloudflare/cloudflared/archive/refs/tags/{{ .CLOUDFLARED_VERSION }}.tar.gz
-        destination: cloudflared.tar.gz
-        sha256: 74794fbcdd7b71131799100d493cf70a8e126cb109f3d9e2abce55593df6a737
-        sha512: cd417fc8410537fd0e59799be750f18b13e5931a5785258833b518aa5f516a479e00af0bbceb9f6e03d7cc6f2da406a956f25f64a57f282de56d9f6c47b281a2
-    env:
-      GOPATH: /go
-    cachePaths:
-      - /.cache/go-build
-      - /go/pkg
+      # {{ if eq .ARCH "x86_64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+      - url: https://github.com/cloudflare/cloudflared/releases/download/{{ .CLOUDFLARED_VERSION }}/cloudflared-linux-amd64
+        destination: cloudflared
+        sha256: b868cfffc393dd9f1c5ae79812353c2ff73cfa95da4c3dcb0ec98ce55d13943d
+        sha512: 1361fc70ceaa072e76beffe838d9721bc2b468f40794d99241771464d65db009662f1609b953ce0856302cccabbb82cd6cbff9f42d3bd10e83b5322cd72dd0b0
+      # {{ else if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+      - url: https://github.com/cloudflare/cloudflared/releases/download/{{ .CLOUDFLARED_VERSION }}/cloudflared-linux-arm64
+        destination: cloudflared
+        sha256: 0642e5e6e793b955969a1bad2a4bfe8b810e4761feefda40c4d02888948212d4
+        sha512: 8bc0d88e36aeff5b4fa5a946fe1ff8e7565065d58790405afe829b7aa99488ef48a5b71762e161c050cba67e25327dbb7dbcb37707a6d36c91d814898585314d
+    # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
     prepare:
       - |
-        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
-      - |
-        tar -xzvf cloudflared.tar.gz --strip-components=1
-    build:
-      - |
-        export PATH=${PATH}:${TOOLCHAIN}/go/bin
-
-        make cloudflared VERSION="{{ .CLOUDFLARED_VERSION}}" DATE="{{ .BUILD_ARG_SOURCE_DATE_EPOCH }}"
+        sed -i 's#$CLOUDFLARED_VERSION#{{ .CLOUDFLARED_VERSION }}#' /pkg/manifest.yaml
     install:
       - |
         mkdir -p /rootfs/usr/local/lib/containers/cloudflared/usr/local/bin
-
         mv cloudflared /rootfs/usr/local/lib/containers/cloudflared/usr/local/bin
+        chmod +x /rootfs/usr/local/lib/containers/cloudflared/usr/local/bin/cloudflared
       - |
         mkdir -p /rootfs/usr/local/etc/containers
         cp /pkg/cloudflared.yaml /rootfs/usr/local/etc/containers/
@@ -45,3 +40,4 @@ finalize:
     to: /rootfs
   - from: /pkg/manifest.yaml
     to: /
+    

--- a/reproducibility/pkg.yaml
+++ b/reproducibility/pkg.yaml
@@ -15,9 +15,8 @@ dependencies:
   # - stage: chelsio-drivers
   # chelsio-firmware can be ignored from reproducibility test since it's linux-firmware copied from pkgs
   # - stage: chelsio-firmware
-
-  - stage: cloudflared
-
+  # cloudflared can be ignored from reproducibility test since it's a tarball downloaded and extracted (no build happens)
+  # - stage: cloudflared
   # drbd can be ignored from reproducibility test since it's kernel modules copied from pkgs
   # crun can be ignored from reproducibility test since it's a tarball downloaded and extracted (no build happens)
   # - stage: crun


### PR DESCRIPTION
Hi, here are the changes linked to this PR https://github.com/siderolabs/extensions/pull/542, to put the binaries back rather than building from the sources.

By the way, I don't understand why you changed the version variable names ([in your commit of the previous PR](https://github.com/siderolabs/extensions/commit/1dd6c364b8aae54a891ef1b371417e4b6b263030)) from ‘.VERSION’ to ‘.CLOUDFALRED_VERSION’. In the end, in the manifest.yaml, you end up replacing some variables with ‘.CLOUDFLARED_VERSION’ and leaves others with ‘.VERSION’, which isn't clear or consistent.
I've replaced everything with ‘.CLOUDFLARED_VERSION’, and deleted the vars.yml file containing the ‘.VERSION’ vars, which is now useless.

Finally, could you remove the current ghcr.io/siderolabs/cloudflared:2024.12.1 image, which is therefore non-compliant, or will it be automatically replaced?

Thanks in advance :)