### PR TITLE
fix: add `gsc_proxy/mei_gsc_proxy` to mei modules

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -65,7 +65,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.10.0-alpha.0-8-g8c31321
+        defaultValue: v1.10.0-alpha.0-9-g86e3755
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
   useBldrPkgTagResolver: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-12-12T11:54:21Z by kres 8183c20.
+# Generated on 2024-12-16T04:55:48Z by kres 8183c20.
 
 # common variables
 
@@ -50,7 +50,7 @@ COMMON_ARGS += --build-arg=PKGS_PREFIX="$(PKGS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.10.0-alpha.0-8-g8c31321
+PKGS ?= v1.10.0-alpha.0-9-g86e3755
 PKGS_PREFIX ?= ghcr.io/siderolabs
 
 # targets defines all the available targets

--- a/drivers/mei/files/modules.txt
+++ b/drivers/mei/files/modules.txt
@@ -1,6 +1,7 @@
 modules.order
 modules.builtin
 modules.builtin.modinfo
+kernel/drivers/misc/mei/gsc_proxy/mei_gsc_proxy.ko
 kernel/drivers/misc/mei/hdcp/mei_hdcp.ko
 kernel/drivers/misc/mei/pxp/mei_pxp.ko
 kernel/drivers/misc/mei/mei-gsc.ko


### PR DESCRIPTION
I am not able to do hardware transcoding with an intel 14th gen CPU and noticed this in dmesg.

```
[drm] GT1: can't init GSC proxy due to missing mei component
```

https://github.com/torvalds/linux/blob/master/drivers/misc/mei/gsc_proxy/Kconfig

Related: https://github.com/siderolabs/pkgs/pull/1116