### PR TITLE
Fix: nvidia-fabricmanager production

### DIFF
--- a/nvidia-gpu/nvidia-fabricmanager/production/nvidia-fabricmanager.yaml
+++ b/nvidia-gpu/nvidia-fabricmanager/production/nvidia-fabricmanager.yaml
@@ -59,15 +59,6 @@ container:
         - rshared
         - rbind
         - ro
-    # even though we set `TOPOLOGY_FILE_PATH=/usr/local/share/nvidia/nvswitch` in the config file,
-    # fabricmanager still tries to use /usr/share/nvidia/nvswitch
-    - source: /usr/local/share/nvidia/nvswitch
-      destination: /usr/share/nvidia/nvswitch
-      type: bind
-      options:
-        - rshared
-        - rbind
-        - ro
     # binaries
     - source: /usr/local/bin
       destination: /usr/local/bin

--- a/nvidia-gpu/nvidia-fabricmanager/production/pkg.yaml
+++ b/nvidia-gpu/nvidia-fabricmanager/production/pkg.yaml
@@ -41,6 +41,7 @@ steps:
 
         cp /pkg/nvidia-fabricmanager.yaml /rootfs/usr/local/etc/containers/nvidia-fabricmanager.yaml
 
+        echo "FABRIC_NODE_CONFIG_FILE=/usr/local/share/nvidia/nvswitch/fabricmanager.cfg" >> /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg # fix for #511
         sed -i 's/DAEMONIZE=.*/DAEMONIZE=0/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
         sed -i 's/STATE_FILE_NAME=.*/STATE_FILE_NAME=\/var\/run\/nvidia-fabricmanager\/fabricmanager.state/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg
         sed -i 's/TOPOLOGY_FILE_PATH=.*/TOPOLOGY_FILE_PATH=\/usr\/local\/share\/nvidia\/nvswitch/g' /rootfs/usr/local/share/nvidia/nvswitch/fabricmanager.cfg


### PR DESCRIPTION
This contains a proper fix for #511 and reverts commit b452bc66b8bc70826a6f737f0fd021119c778562.