### PR TITLE
fix: dvb cx23885 module loading

### DIFF
--- a/dvb/cx23885/files/modules.txt
+++ b/dvb/cx23885/files/modules.txt
@@ -1,3 +1,4 @@
+modules.dep
 modules.order
 modules.builtin
 modules.builtin.modinfo


### PR DESCRIPTION
I believe that because this is not included, it's not able to load it properly.