### PR TITLE
feat: mount host ca certs into metal agent

### DIFF
--- a/guest-agents/metal-agent/metal-agent.yaml
+++ b/guest-agents/metal-agent/metal-agent.yaml
@@ -18,8 +18,15 @@ container:
         - rshared
         - rbind
         - rw
+    - source: /etc/ssl/certs
+      destination: /etc/ssl/certs
+      type: bind
+      options:
+        - rbind
+        - ro
 depends:
   - path: /system/run/machined/machine.sock
+  - path: /etc/ssl/certs
   - network:
       - addresses
 restart: always

--- a/guest-agents/metal-agent/pkg.yaml
+++ b/guest-agents/metal-agent/pkg.yaml
@@ -7,10 +7,6 @@ dependencies:
     from: /
     to: /rootfs/usr/local/lib/containers/metal-agent
 
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/ca-certificates:{{ .BUILD_ARG_PKGS }}"
-    from: /
-    to: /rootfs/usr/local/lib/containers/metal-agent
-
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/openssl:{{ .BUILD_ARG_PKGS }}"
     from: /
     to: /rootfs/usr/local/lib/containers/metal-agent

--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -9,4 +9,4 @@ XEN_GUEST_AGENT_VERSION: 0.4.0
 # renovate: datasource=github-releases depName=siderolabs/talos-vmtoolsd
 TALOS_VMTOOLSD_VERSION: v0.6.1
 # renovate: datasource=github-releases depName=siderolabs/talos-metal-agent
-TALOS_METAL_AGENT_VERSION: v0.1.0-beta.1
+TALOS_METAL_AGENT_VERSION: v0.1.0


### PR DESCRIPTION
Instead of copying ca certs from its image, mount them from the host into the agent container. This way, agent can also use additional ca certificates added via `TrustedRootsConfig` config documents.

Also bump the agent version to `v0.1.0`.