### PR TITLE
feat: bump metal agent to v0.1.2

### DIFF
--- a/guest-agents/metal-agent/pkg.yaml
+++ b/guest-agents/metal-agent/pkg.yaml
@@ -4,22 +4,6 @@ shell: /bin/bash
 dependencies:
   - stage: base
 
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/fhs:{{ .BUILD_ARG_PKGS }}"
-    from: /
-    to: /rootfs/usr/local/lib/containers/metal-agent
-
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/openssl:{{ .BUILD_ARG_PKGS }}"
-    from: /
-    to: /rootfs/usr/local/lib/containers/metal-agent
-
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/musl:{{ .BUILD_ARG_PKGS }}"
-    from: /
-    to: /rootfs/usr/local/lib/containers/metal-agent
-
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/ipmitool:{{ .BUILD_ARG_PKGS }}"
-    from: /
-    to: /rootfs/usr/local/lib/containers/metal-agent
-
   - image: "{{ .IMAGE_PREFIX }}/talos-metal-agent:{{ .VERSION }}"
     from: /
     to: /rootfs/usr/local/lib/containers/metal-agent

--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -9,4 +9,4 @@ XEN_GUEST_AGENT_VERSION: 5c274e651c29f92fc0c418fda486373b0f34f0da
 # renovate: datasource=github-releases depName=siderolabs/talos-vmtoolsd
 TALOS_VMTOOLSD_VERSION: v0.6.1
 # renovate: datasource=github-releases depName=siderolabs/talos-metal-agent
-TALOS_METAL_AGENT_VERSION: v0.1.0
+TALOS_METAL_AGENT_VERSION: v0.1.2


### PR DESCRIPTION
Since we switch to native IPMI implementation in Go, we don't need to shell out to ipmitool. Remove it and its dependencies.

See https://github.com/siderolabs/talos-metal-agent/releases/tag/v0.1.2.
Part of https://github.com/siderolabs/omni/issues/896.