### PR TITLE
fix: pin go version to 1.23 for nvidia tools

### DIFF
--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/lts/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/lts/pkg.yaml
@@ -4,7 +4,7 @@ shell: /bin/bash
 install:
   - build-base
   - bash
-  - go
+  - go-1.23
   - coreutils
   - sed
   - curl

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/production/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/production/pkg.yaml
@@ -4,7 +4,7 @@ shell: /bin/bash
 install:
   - build-base
   - bash
-  - go
+  - go-1.23
   - coreutils
   - sed
   - curl

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/pkg.yaml
@@ -4,7 +4,7 @@ shell: /bin/bash
 install:
   - build-base
   - bash
-  - go
+  - go-1.23
   - patch
 dependencies:
   - image: cgr.dev/chainguard/wolfi-base@{{ .WOLFI_BASE_REF }}


### PR DESCRIPTION
Pin Go version to 1.23 for NVIDIA tools, since upstream doesn't build with Go 1.24 without patches.