### PR TITLE
backport: fix: use proper stub for vmtoolsd on arm64

### DIFF
--- a/guest-agents/vmtoolsd-guest-agent/pkg.yaml
+++ b/guest-agents/vmtoolsd-guest-agent/pkg.yaml
@@ -2,9 +2,19 @@ name: vmtoolsd-guest-agent
 variant: scratch
 # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
 # VMWare doesn't support arm64
+dependencies:
+  - stage: base
+steps:
+  - prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/stub-manifest.yaml
+      - |
+        mkdir /rootfs
 finalize:
-  - from: /
-    to: /
+  - from: /pkg/stub-manifest.yaml
+    to: /manifest.yaml
+  - from: /rootfs
+    to: /rootfs
 # {{ else }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
 dependencies:
   - stage: base

--- a/guest-agents/vmtoolsd-guest-agent/stub-manifest.yaml
+++ b/guest-agents/vmtoolsd-guest-agent/stub-manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: vmtoolsd-guest-agent
+  version: "$VERSION"
+  author: Brandon Nason
+  description: |
+    A stub for the VMWare Tools on arm64 (unavailable on arm64).
+  compatibility:
+    talos:
+      version: ">= v1.4.0"


### PR DESCRIPTION
Empty extension image for arm64 makes imager fail on arm64, and specifically Image Factory when generating arm64 image.

Signed-off-by: Andrey Smirnov <andrey.smirnov@siderolabs.com>
(cherry picked from commit aa141a6a7539c99c3f3f3c7116644167033fa1f7)