### PR TITLE
chore: remove duplicate lines

### DIFF
--- a/container-runtime/kata-containers/pkg.yaml
+++ b/container-runtime/kata-containers/pkg.yaml
@@ -52,9 +52,6 @@ steps:
         cp ./opt/kata/bin/cloud-hypervisor /rootfs/usr/local/bin/cloud-hypervisor
         chmod +x /rootfs/usr/local/bin/cloud-hypervisor
 
-        cp ./opt/kata/bin/cloud-hypervisor /rootfs/usr/local/bin/cloud-hypervisor
-        chmod +x /rootfs/usr/local/bin/cloud-hypervisor
-
         cp ./opt/kata/libexec/virtiofsd /rootfs/usr/local/libexec/virtiofsd
         chmod +x /rootfs/usr/local/libexec/virtiofsd
 


### PR DESCRIPTION
I was reviewing pkg.yml file and noticed a few lines that appear to be duplicated. Specifically, the following block is repeated:

```bash
cp ./opt/kata/bin/cloud-hypervisor /rootfs/usr/local/bin/cloud-hypervisor
chmod +x /rootfs/usr/local/bin/cloud-hypervisor
```

Let me know. If this makes sense, I’d be happy to assist with the update.

Thanks for your hard work on this