### PR TITLE
Correct typo in lldpd extension

### DIFF
--- a/network/lldpd/README.md
+++ b/network/lldpd/README.md
@@ -18,7 +18,7 @@ kind: ExtensionServiceConfig
 name: lldpd
 configFiles:
   - content: |
-      configure lldpd portidsubtype ifname
+      configure lldp portidsubtype ifname
       unconfigure lldp management-addresses-advertisements
       unconfigure lldp capabilities-advertisements
       configure system description "Talos Node"


### PR DESCRIPTION
Fix command recognition issue: change `lldpd` to `lldp`

https://github.com/siderolabs/extensions/tree/main/network/lldpd


```
apiVersion: v1alpha1
kind: ExtensionServiceConfig
name: lldpd
configFiles:
  - content: |
      configure lldpd <-[**  HERE   **] portidsubtype ifname
      unconfigure lldp management-addresses-advertisements
      unconfigure lldp capabilities-advertisements

```

This PR fixes a command recognition issue in `lldpd` extension. Previously, using `lldpd` as a command argument resulted in an unknown command error. According to the [official documentation](https://lldpd.github.io/usage.html), the correct command should be `lldp`.

#### Issue
Before the fix, executing the command produced the following warning:

```
x.x.x.x: 2025-02-19T03:01:31 [WARN/lldpctl] unknown command from argument 2: `lldpd`
x.x.x.x: 2025-02-19T03:01:31 [INFO/lldpctl] an error occurred while executing last command
```

#### Fix
After replacing `lldpd` with `lldp`, the command executes correctly:

```
x.x.x.x: 2025-02-19T03:10:56 [INFO/lldpctl] LLDP PortID TLV type set to new value : ifname
```

No functional changes beyond correcting the command syntax.