### PR TITLE
feat: add extenstion for panfrost module

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -39,6 +39,7 @@ spec:
     - nvidia-open-gpu-kernel-modules-lts
     - nvidia-open-gpu-kernel-modules-production
     - nvme-cli
+    - panfrost
     - qemu-guest-agent
     - qlogic-firmware
     - realtek-firmware
@@ -70,7 +71,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.10.0-alpha.0-52-g1d84473
+        defaultValue: v1.10.0-alpha.0-54-ga4ac508
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
       - name: TOOLS

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -47,6 +47,7 @@ If the field is marked as `Needs Maintainer`, it means that the package is curre
 | nvme-cli                                  | Sidelo Labs        | NA                                                                   |
 | nonfree-kmod-nvidia-lts                   | Sidero Labs        | NA                                                                   |
 | nonfree-kmod-nvidia-production            | Sidero Labs        | NA                                                                   |
+| panfrost                                  | Adam Cirillo       | [adamcirillo](https://github.com/adamcirillo)                        |
 | qemu-guest-agent                          | Markus Reiter      | [reitermarkus](https://github.com/reitermarkus)                      |
 | qlogic-firmware                           | Sidero Labs        | NA                                                                   |
 | realtek-firmware                          | Sidero Labs        | NA                                                                   |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-03-05T16:36:46Z by kres e2c7efe.
+# Generated on 2025-03-12T08:58:48Z by kres ec5ec04.
 
 # common variables
 
@@ -50,7 +50,7 @@ COMMON_ARGS += --build-arg=TOOLS_PREFIX="$(TOOLS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.10.0-alpha.0-52-g1d84473
+PKGS ?= v1.10.0-alpha.0-54-ga4ac508
 PKGS_PREFIX ?= ghcr.io/siderolabs
 TOOLS ?= v1.10.0-alpha.0-19-g87acb27
 TOOLS_PREFIX ?= ghcr.io/siderolabs
@@ -94,6 +94,7 @@ TARGETS += nvidia-fabricmanager-production
 TARGETS += nvidia-open-gpu-kernel-modules-lts
 TARGETS += nvidia-open-gpu-kernel-modules-production
 TARGETS += nvme-cli
+TARGETS += panfrost
 TARGETS += qemu-guest-agent
 TARGETS += qlogic-firmware
 TARGETS += realtek-firmware

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ cosign verify --certificate-identity-regexp '@siderolabs\.com$' --certificate-oi
 
 ### Direct Rendering Manager (DRM)
 
-| Name                  | Image                                                                                       | Description                    | Version Format                           |
-| --------------------- | ------------------------------------------------------------------------------------------- | ------------------------------ | ---------------------------------------- |
-| [amdgpu](drm/amdgpu/) | [ghcr.io/siderolabs/amdgpu](https://github.com/siderolabs/extensions/pkgs/container/amdgpu) | AMD GPU firmware and drivers   | `linux firmware version`-`talos version` |
-| [i915](drm/i915/)     | [ghcr.io/siderolabs/i915](https://github.com/siderolabs/extensions/pkgs/container/i915)     | Intel GPU firmware and drivers | `linux firmware version`-`talos version` |
+| Name                     | Image                                                                                           | Description                       | Version Format                           |
+| ------------------------ | ----------------------------------------------------------------------------------------------- | --------------------------------- | ---------------------------------------- |
+| [amdgpu](drm/amdgpu/)    | [ghcr.io/siderolabs/amdgpu](https://github.com/siderolabs/extensions/pkgs/container/amdgpu)     | AMD GPU firmware and drivers      | `linux firmware version`-`talos version` |
+| [i915](drm/i915/)        | [ghcr.io/siderolabs/i915](https://github.com/siderolabs/extensions/pkgs/container/i915)         | Intel GPU firmware and drivers    | `linux firmware version`-`talos version` |
+| [panfrost](drm/panfrost) | [ghcr.io/siderolabs/panfrost](https://github.com/siderolabs/extensions/pkgs/container/panfrost) | Panfrost GPU firmware and drivers | `linux firmware version`-`talos version` |
 
 ### Drivers
 
@@ -112,7 +113,7 @@ cosign verify --certificate-identity-regexp '@siderolabs\.com$' --certificate-oi
 | [drbd](storage/drbd/)               | [ghcr.io/siderolabs/drbd](https://github.com/siderolabs/extensions/pkgs/container/drbd)               | DRBD driver module     | `upstream version`-`talos version` |
 | [iscsi-tools](storage/iscsi-tools/) | [ghcr.io/siderolabs/iscsi-tools](https://github.com/siderolabs/extensions/pkgs/container/iscsi-tools) | Open iSCSI tools       | `v0.1.0`                           |
 | [mdadm](storage/mdadm/)             | [ghcr.io/siderolabs/mdadm](https://github.com/siderolabs/extensions/pkgs/container/mdadm)             | manage MD devices tool | `upstream version`                 |
-| [nfsd](storage/nfsd/)               | [ghcr.io/siderolabs/nfsd](https://github.com/siderolabs/extensions/pkgs/container/nfsd)               | nfsd kernel module     | `talos version`                 |
+| [nfsd](storage/nfsd/)               | [ghcr.io/siderolabs/nfsd](https://github.com/siderolabs/extensions/pkgs/container/nfsd)               | nfsd kernel module     | `talos version`                    |
 | [zfs](storage/zfs/)                 | [ghcr.io/siderolabs/zfs](https://github.com/siderolabs/extensions/pkgs/container/zfs)                 | ZFS driver module      | `upstream version`-`talos version` |
 
 ### Power

--- a/drm/panfrost/files/modules.txt
+++ b/drm/panfrost/files/modules.txt
@@ -1,0 +1,5 @@
+modules.order
+modules.builtin
+modules.builtin.modinfo
+kernel/drivers/gpu/drm/panfrost/panfrost.ko
+

--- a/drm/panfrost/manifest.yaml
+++ b/drm/panfrost/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: panfrost
+  version: "$VERSION"
+  author: Adam Cirillo
+  description: |
+    This system extension provides ARM Mali Midgard & Bifrost firmware binaries and kernel modules.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"

--- a/drm/panfrost/pkg.yaml
+++ b/drm/panfrost/pkg.yaml
@@ -1,0 +1,49 @@
+name: panfrost
+variant: scratch
+shell: /bin/bash
+# {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+dependencies:
+  - stage: base
+  # The pkgs version for a particular release of Talos as defined in
+  # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+
+        mkdir -p /rootfs
+  - install:
+      - |
+        export KERNELRELEASE=$(find /usr/lib/modules -type d -name "*-talos" -exec basename {} \+)
+
+        xargs -a /pkg/files/modules.txt -I {} install -D /usr/lib/modules/${KERNELRELEASE}/{} /rootfs/usr/lib/modules/${KERNELRELEASE}/{}
+  - test:
+      - |
+        # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping
+        find /rootfs/usr/lib/modules -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+      - |
+        mkdir -p /extensions-validator-rootfs
+        cp -r /rootfs/ /extensions-validator-rootfs/rootfs
+        cp /pkg/manifest.yaml /extensions-validator-rootfs/manifest.yaml
+        /extensions-validator validate --rootfs=/extensions-validator-rootfs --pkg-name="${PKG_NAME}"
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /
+# {{ else }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+dependencies:
+  - stage: base
+steps:
+  - prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+      - |
+        mkdir /rootfs
+finalize:
+  - from: /pkg/manifest.yaml
+    to: /manifest.yaml
+  - from: /rootfs
+    to: /rootfs
+  # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr

--- a/drm/panfrost/vars.yaml
+++ b/drm/panfrost/vars.yaml
@@ -1,0 +1,1 @@
+VERSION: "{{ .BUILD_ARG_TAG }}"


### PR DESCRIPTION
This extension loads the panfrost module for arm mali midgard & birfrost gpus used by various sbcs. I've compiled the extension the _out folder only had the manifest.yaml and the bldr file this seemed the same as the amd gpu drm module so i'm thinking this is correct. Also is there anything else I need to do to add this to image factory or this it pick this up automatically once merged? Also updated the makefile with the kernel build that has the panfrost module.