### PR TITLE
feat: bump dependencies

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -77,11 +77,11 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.10.0-alpha.0-72-g7d7323b
+        defaultValue: v1.10.0-alpha.0-74-ga09be59
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
       - name: TOOLS
-        defaultValue: v1.10.0-alpha.0-23-g6d456ca
+        defaultValue: v1.10.0-alpha.0-24-g4f2036e
       - name: TOOLS_PREFIX
         defaultValue: ghcr.io/siderolabs
   useBldrPkgTagResolver: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-04-01T08:20:01Z by kres d903dae.
+# Generated on 2025-04-02T15:35:29Z by kres d903dae.
 
 # common variables
 
@@ -50,9 +50,9 @@ COMMON_ARGS += --build-arg=TOOLS_PREFIX="$(TOOLS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.10.0-alpha.0-72-g7d7323b
+PKGS ?= v1.10.0-alpha.0-74-ga09be59
 PKGS_PREFIX ?= ghcr.io/siderolabs
-TOOLS ?= v1.10.0-alpha.0-23-g6d456ca
+TOOLS ?= v1.10.0-alpha.0-24-g4f2036e
 TOOLS_PREFIX ?= ghcr.io/siderolabs
 
 # targets defines all the available targets

--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@ format: v1alpha2
 vars:
   CONTAINERD_VERSION: v2.0.4 # update this when updating PKGS_VERSION in Makefile
   LINUX_FIRMWARE_VERSION: "20250311" # update this when updating PKGS_VERSION in Makefile
-  DRBD_DRIVER_VERSION: 9.2.12 # update this when updating PKGS_VERSION in Makefile
+  DRBD_DRIVER_VERSION: 9.2.13 # update this when updating PKGS_VERSION in Makefile
   ZFS_DRIVER_VERSION: 2.3.1 # update this when updating PKGS_VERSION in Makefile
   ZFS_TOOLS_SHA256: 053233799386920bdc636e22d0e19a8c2c3e642e8bd847ff87e108f8bb1f9006
   ZFS_TOOLS_SHA512: 235023dbe97b3f7c5273e2a6fa34957cc37967256845d4ed9faa2e2a6da29ea6fdcba4167658cf03129afbb0aa11311a760d3d0b5ea5aecc64a4c7ee22ad2d31

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -27,6 +27,7 @@ spin: 0.18.0
 qemu-guest-agent: 9.2.2
 Tailscale: 1.80.3
 ZFS: 2.3.1
+DRBD: 9.2.13
 NVIDIA LTS: 535.230.02
 NVIDIA Production: 570.124.06
 NVIDIA Container Toolkit: 1.17.4


### PR DESCRIPTION
Bring in new tools/pkgs.

No other bumps, as Renovate is broken :sad:.