### PR TITLE
chore: update pkgs to final 1.10.0 tag

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -77,7 +77,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.10.0-alpha.0-80-g0486742
+        defaultValue: v1.10.0
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
       - name: TOOLS

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-04-11T16:36:07Z by kres d903dae.
+# Generated on 2025-04-14T09:18:28Z by kres d903dae.
 
 # common variables
 
@@ -50,7 +50,7 @@ COMMON_ARGS += --build-arg=TOOLS_PREFIX="$(TOOLS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.10.0-alpha.0-80-g0486742
+PKGS ?= v1.10.0
 PKGS_PREFIX ?= ghcr.io/siderolabs
 TOOLS ?= v1.10.0
 TOOLS_PREFIX ?= ghcr.io/siderolabs


### PR DESCRIPTION
This is a no-op change, as it matches the previous tag, but to get things into proper shape before upcoming 1.10.0-beta.0 release.