### PR TITLE
feat(bcache): create bcache extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ COMMON_ARGS += --build-arg=TOOLS_PREFIX="$(TOOLS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.11.0-alpha.0
+PKGS ?= v1.11.0-alpha.0-2-gcb108a5
 PKGS_PREFIX ?= ghcr.io/siderolabs
 TOOLS ?= v1.10.0
 TOOLS_PREFIX ?= ghcr.io/siderolabs
@@ -60,6 +60,7 @@ TOOLS_PREFIX ?= ghcr.io/siderolabs
 TARGETS = amazon-ena
 TARGETS += amdgpu
 TARGETS += amd-ucode
+TARGETS += bcache
 TARGETS += binfmt-misc
 TARGETS += bnx2-bnx2x
 TARGETS += btrfs

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ cosign verify --certificate-identity-regexp '@siderolabs\.com$' --certificate-oi
 | Name                                | Image                                                                                                 | Description            | Version Format                     |
 | ----------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------- | ---------------------------------- |
 | [btrfs](storage/btrfs/)             | [ghcr.io/siderolabs/btrfs](https://github.com/siderolabs/extensions/pkgs/container/btrfs)             | BTRFS driver module    | `talos version`                    |
+| [bcache](storage/bcache/)           | [ghcr.io/siderolabs/bcache](https://github.com/siderolabs/extensions/pkgs/container/bcache)           | Bcache driver module   | `talos version`                    |
 | [drbd](storage/drbd/)               | [ghcr.io/siderolabs/drbd](https://github.com/siderolabs/extensions/pkgs/container/drbd)               | DRBD driver module     | `upstream version`-`talos version` |
 | [iscsi-tools](storage/iscsi-tools/) | [ghcr.io/siderolabs/iscsi-tools](https://github.com/siderolabs/extensions/pkgs/container/iscsi-tools) | Open iSCSI tools       | `v0.1.0`                           |
 | [mdadm](storage/mdadm/)             | [ghcr.io/siderolabs/mdadm](https://github.com/siderolabs/extensions/pkgs/container/mdadm)             | manage MD devices tool | `upstream version`                 |

--- a/storage/bcache/README.md
+++ b/storage/bcache/README.md
@@ -1,0 +1,20 @@
+# bcache
+
+This extension provides kernel module needed to use bcache. 
+
+Bcache is a Linux kernel block layer cache. It allows one or more fast disk drives such as flash-based solid state drives (SSDs) to act as a cache for one or more slower hard disk drives.
+
+## Installation
+
+See [Installing Extensions](https://github.com/siderolabs/extensions#installing-extensions).
+
+## Usage
+
+Enable the module in Talos machine config:
+
+```yaml
+machine:
+  kernel:
+    modules:
+      - name: bcache
+```

--- a/storage/bcache/files/modules.txt
+++ b/storage/bcache/files/modules.txt
@@ -1,0 +1,4 @@
+modules.order
+modules.builtin
+modules.builtin.modinfo
+kernel/drivers/md/bcache/bcache.ko

--- a/storage/bcache/manifest.yaml
+++ b/storage/bcache/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: bcache
+  version: "$VERSION"
+  author: Marat Bakeev
+  description: |
+    This system extension provides kernel module driver for bcache built against a specific Talos version.
+  compatibility:
+    talos:
+      version: ">= v1.5.0"

--- a/storage/bcache/pkg.yaml
+++ b/storage/bcache/pkg.yaml
@@ -1,0 +1,30 @@
+name: bcache
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+  - install:
+      - |
+        export KERNELRELEASE=$(find /usr/lib/modules -type d -name "*-talos" -exec basename {} \+)
+        find /usr/lib/modules/${KERNELRELEASE} -name "*.ko*"
+        mkdir -p /rootfs
+        xargs -a /pkg/files/modules.txt -I {} install -D /usr/lib/modules/${KERNELRELEASE}/{} /rootfs/usr/lib/modules/${KERNELRELEASE}/{}
+        depmod -b /rootfs/usr ${KERNELRELEASE}
+  - test:
+      - |
+        find /rootfs/usr/lib/modules -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+      - |
+        mkdir -p /extensions-validator-rootfs
+        cp -r /rootfs/ /extensions-validator-rootfs/rootfs
+        cp /pkg/manifest.yaml /extensions-validator-rootfs/manifest.yaml
+        /extensions-validator validate --rootfs=/extensions-validator-rootfs --pkg-name="${PKG_NAME}"
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/storage/bcache/vars.yaml
+++ b/storage/bcache/vars.yaml
@@ -1,0 +1,1 @@
+VERSION: "{{ .BUILD_ARG_TAG }}"


### PR DESCRIPTION
Hi team, I'm proposing to add the bcache kernel module as an extension.

Talos already has a DRBD extension, which allows us to use Linstor storage.
Linstor also supports using **bcache** as a caching layer [(example config)](https://linbit.com/blog/tutorial-stacked-block-storage-in-linbit-sds-aka-linstor/).

This is a very simple extension, which adds a kernel module (I used binfmt_misc as an example).

Please let me know if any more changes are required.