### PR TITLE
feat(panfrost): include panthor kernel module

### DIFF
--- a/drm/panfrost/files/modules.txt
+++ b/drm/panfrost/files/modules.txt
@@ -1,5 +1,6 @@
 modules.order
 modules.builtin
 modules.builtin.modinfo
+kernel/drivers/gpu/drm/drm_gpuvm.ko
 kernel/drivers/gpu/drm/panfrost/panfrost.ko
-
+kernel/drivers/gpu/drm/panthor/panthor.ko

--- a/drm/panfrost/manifest.yaml
+++ b/drm/panfrost/manifest.yaml
@@ -4,7 +4,7 @@ metadata:
   version: "$VERSION"
   author: Adam Cirillo
   description: |
-    This system extension provides ARM Mali Midgard & Bifrost firmware binaries and kernel modules.
+    This system extension provides ARM Mali Midgard, Bifrost, and Valhall firmware binaries and kernel modules.
   compatibility:
     talos:
       version: ">= v1.0.0"


### PR DESCRIPTION
This PR adds panthor module in panfrost extension to support Valhall GPUs