### PR TITLE
chore: update pkgs and zstd module

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -78,7 +78,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.11.0-alpha.0-10-g4cd7084
+        defaultValue: v1.11.0-alpha.0-11-gc6b54e0
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
       - name: TOOLS

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-05-08T15:26:39Z by kres 5ad3e5f.
+# Generated on 2025-05-14T14:44:43Z by kres 5ad3e5f.
 
 # common variables
 
@@ -50,7 +50,7 @@ COMMON_ARGS += --build-arg=TOOLS_PREFIX="$(TOOLS_PREFIX)"
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.11.0-alpha.0-10-g4cd7084
+PKGS ?= v1.11.0-alpha.0-11-gc6b54e0
 PKGS_PREFIX ?= ghcr.io/siderolabs
 TOOLS ?= v1.11.0-alpha.0-1-ge35234b
 TOOLS_PREFIX ?= ghcr.io/siderolabs

--- a/storage/btrfs/files/modules.txt
+++ b/storage/btrfs/files/modules.txt
@@ -2,6 +2,5 @@ modules.order
 modules.builtin
 modules.builtin.modinfo
 kernel/crypto/blake2b_generic.ko
-kernel/crypto/zstd.ko
 kernel/crypto/xxhash_generic.ko
 kernel/fs/btrfs/btrfs.ko


### PR DESCRIPTION
With https://github.com/siderolabs/pkgs/pull/1228, the zstd is no longer a module, but part of the kernel.