### PR TITLE
fix: staticallty link ecr-credential-provider

### DIFF
--- a/container-runtime/ecr-credential-provider/pkg.yaml
+++ b/container-runtime/ecr-credential-provider/pkg.yaml
@@ -28,7 +28,7 @@ steps:
   - network: none
     build:
       - |
-        go build \
+        CGO_ENABLED=0 go build \
           -C ${GOPATH}/src/k8s.io/cloud-provider-aws \
           -o ./dist/ecr-credential-provider \
           -ldflags "-s -w \


### PR DESCRIPTION
The bump to v1.33 changed the binary to be dynamically linked. Explicitly set `CGO_ENABLED=0` while building.

Fixes: #706