### PR TITLE
fix: tailscale static builds

### DIFF
--- a/network/tailscale/pkg.yaml
+++ b/network/tailscale/pkg.yaml
@@ -27,7 +27,7 @@ steps:
   - network: none
     build:
       - |
-        go build \
+        CGO_ENABLED=0 go build \
           -C tailscale \
           -o ../dist \
         	-ldflags "-X tailscale.com/version.shortStamp={{ .TAILSCALE_VERSION }} \


### PR DESCRIPTION
Moving to new toolchain meant we didn't set `CGO_ENABLED=0` from bldr anymore. Explicitly set it.