### PR TITLE
fix(glibc): use lib64 for better compatibility

### DIFF
--- a/misc/glibc/ld.so.conf
+++ b/misc/glibc/ld.so.conf
@@ -1,1 +1,2 @@
+/usr/local/glibc/usr/lib64
 /usr/local/glibc/usr/lib

--- a/misc/glibc/pkg.yaml
+++ b/misc/glibc/pkg.yaml
@@ -24,12 +24,16 @@ steps:
         mkdir build
         cd build
 
+        echo "libc_cv_slibdir=/usr/local/glibc/usr/lib64" > config.cache
         ../configure \
           --prefix=/usr/local/glibc \
-          --libdir=/usr/local/glibc/usr/lib \
-          --libexecdir=/usr/local/glibc/usr/lib \
-          --enable-stack-protection=strong \
-          --disable-werror
+          --bindir=/usr/local/glibc/usr/bin \
+          --sbindir=/usr/local/glibc/usr/sbin \
+          --libdir=/usr/local/glibc/usr/lib64 \
+          --libexecdir=/usr/local/glibc/usr/libexec \
+          --enable-stack-protector=strong \
+          --disable-werror \
+          --cache-file=config.cache
     build:
       - |
         cd build
@@ -39,24 +43,25 @@ steps:
         mkdir -p \
           /rootfs/usr/local/glibc/usr/bin \
           /rootfs/usr/local/glibc/usr/lib \
-          /rootfs/usr/local/glibc/usr/lib32 \
+          /rootfs/usr/local/glibc/usr/lib64 \
+          /rootfs/usr/local/glibc/usr/libexec \
           /rootfs/usr/local/glibc/usr/sbin
-        ln -s usr/bin/ /rootfs/usr/local/glibc/bin
-        ln -s usr/lib/ /rootfs/usr/local/glibc/lib
-        ln -s usr/lib/ /rootfs/usr/local/glibc/lib64
-        ln -s usr/sbin/ /rootfs/usr/local/glibc/sbin
-        ln -s lib/ /rootfs/usr/local/glibc/usr/lib64
+        ln -s usr/bin /rootfs/usr/local/glibc/bin
+        ln -s usr/lib /rootfs/usr/local/glibc/lib
+        ln -s usr/lib64 /rootfs/usr/local/glibc/lib64
+        ln -s usr/sbin /rootfs/usr/local/glibc/sbin
 
         cd build
         make install DESTDIR=/rootfs
 
         cp /pkg/ld.so.conf /rootfs/usr/local/glibc/etc/ld.so.conf
 
+        # Talos has /lib{64} -> /usr/lib, /{s}bin -> /usr/bin.
+        # Need to make '/sbin/ldconfig' and '/lib64/ld-linux-x86-64.so.2' work for compatibility.
         mkdir -p /rootfs/usr/lib /rootfs/usr/bin
-        ln -s /usr/local/glibc/usr/lib/ld-linux-x86-64.so.2 /rootfs/usr/lib/ld-linux-x86-64.so.2
+        ln -s /usr/local/glibc/usr/lib64/ld-linux-x86-64.so.2 /rootfs/usr/lib/ld-linux-x86-64.so.2
         ln -s /usr/local/glibc/usr/sbin/ldconfig /rootfs/usr/bin/ldconfig
 
-        # cleanup
         rm -rf /rootfs/usr/local/glibc/include
         rm -rf /rootfs/usr/local/glibc/share
         rm -rf /rootfs/usr/local/glibc/var


### PR DESCRIPTION
This patch changes the glibc extension to use the `lib64` directory for libraries instead of `lib`. This better reflects a standard Fedora/FHS/LSB distribution and fixes issues with a few containers, with the Nvidia Linux installer, and with the Nvidia container toolkit.

The Nvidia container toolkit mounts libraries at the same path as the host system and runs `ldconfig` to update the cache. Mounting 64-bit libraries in `lib` is wrong on Fedora-like _and_ Ubuntu-like distributions.