### PR TITLE
fix: nebula extension spec

### DIFF
--- a/internal/base/pkg.yaml
+++ b/internal/base/pkg.yaml
@@ -3,7 +3,7 @@ variant: scratch
 shell: /bin/bash
 dependencies:
   - image: "{{ .BUILD_ARG_TOOLS_PREFIX }}/tools:{{ .BUILD_ARG_TOOLS }}"
-  - image: ghcr.io/siderolabs/extensions-validator:7d4395d
+  - image: ghcr.io/siderolabs/extensions-validator:fe85801
 finalize:
   - from: /
     to: /

--- a/network/nebula/nebula.yaml
+++ b/network/nebula/nebula.yaml
@@ -8,17 +8,18 @@ depends:
   - configuration: true
 container:
   entrypoint: /usr/local/bin/nebula
-  args: 
-    - -config 
-    - /usr/local/etc/nebula/config.yml 
+  args:
+    - -config
+    - /usr/local/etc/nebula/config.yml
   security:
     writeableRootfs: false
     writeableSysfs: true
-  ## Nebula needs to write to this to create the interfaces
-  - source: /dev/net/tun
-    destination: /dev/net/tun
-    type: bind
-    options:
-      - bind
-      - rw
+  mounts:
+    ## Nebula needs to write to this to create the interfaces
+    - source: /dev/net/tun
+      destination: /dev/net/tun
+      type: bind
+      options:
+        - bind
+        - rw
 restart: always


### PR DESCRIPTION
The spec was missing the `mounts` key.

Fixes: https://github.com/siderolabs/talos/discussions/11108