### PR TITLE
fix: nvidia builds

### DIFF
--- a/misc/glibc/pkg.yaml
+++ b/misc/glibc/pkg.yaml
@@ -3,6 +3,7 @@ variant: scratch
 shell: /bin/bash
 install:
   - build-base
+  - gcc-14
   - bash
   - gawk
   - bison
@@ -10,7 +11,10 @@ install:
 dependencies:
   - image: cgr.dev/chainguard/wolfi-base@{{ .WOLFI_BASE_REF }}
 steps:
-  - sources:
+  - env:
+      CC: gcc-14
+      CXX: g++-14
+    sources:
       - url: https://src.fedoraproject.org/lookaside/pkgs/glibc/glibc-{{ .GLIBC_VERSION }}-8-g1e0e33e1b1.tar.xz/sha512/449e3d4f6b59bfde2175c5d1be71447b084e0b12b176518b65fd9b0ac8430766b25416a173fe3efd47462bc1719d59a051e7eed9544e0fba9165dd86f69ee0b9/glibc-{{ .GLIBC_VERSION }}-8-g1e0e33e1b1.tar.xz
         destination: glibc.tar.xz
         sha256: {{ .GLIBC_SHA256 }}

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/elfutils/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/elfutils/pkg.yaml
@@ -3,6 +3,7 @@ variant: scratch
 shell: /bin/bash
 install:
   - build-base
+  - gcc-14
   - bash
   - m4
 dependencies:
@@ -10,7 +11,10 @@ dependencies:
   - stage: zlib
     from: /rootfs
 steps:
-  - sources:
+  - env:
+      CC: gcc-14
+      CXX: g++-14
+    sources:
       - url: https://sourceware.org/elfutils/ftp/{{ .ELFUTILS_VERSION }}/elfutils-{{ .ELFUTILS_VERSION }}.tar.bz2
         destination: elfutils.tar.bz2
         sha256: {{ .ELFUTILS_SHA256 }}

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libcap2/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libcap2/pkg.yaml
@@ -3,12 +3,16 @@ variant: scratch
 shell: /bin/bash
 install:
   - build-base
+  - gcc-14
   - bash
   - patch
 dependencies:
   - image: cgr.dev/chainguard/wolfi-base@{{ .WOLFI_BASE_REF }}
 steps:
-  - sources:
+  - env:
+      CC: gcc-14
+      CXX: g++-14
+    sources:
       - url: https://kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-{{ .LIBCAP_VERSION }}.tar.xz
         destination: libcap.tar.xz
         sha256: {{ .LIBCAP_SHA256 }}

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libseccomp/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libseccomp/pkg.yaml
@@ -3,12 +3,16 @@ variant: scratch
 shell: /bin/bash
 install:
   - build-base
+  - gcc-14
   - bash
   - gperf
 dependencies:
   - image: cgr.dev/chainguard/wolfi-base@{{ .WOLFI_BASE_REF }}
 steps:
-  - sources:
+  - env:
+      CC: gcc-14
+      CXX: g++-14
+    sources:
       - url: https://github.com/seccomp/libseccomp/releases/download/v{{ .LIBSECCOMP_VERSION }}/libseccomp-{{ .LIBSECCOMP_VERSION }}.tar.gz
         destination: libseccomp.tar.gz
         sha256: {{ .LIBSECCOMP_SHA256 }}

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libtirpc/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/libtirpc/pkg.yaml
@@ -4,12 +4,16 @@ variant: scratch
 shell: /bin/bash
 install:
   - build-base
+  - gcc-14
   - bash
   - autoconf
 dependencies:
   - image: cgr.dev/chainguard/wolfi-base@{{ .WOLFI_BASE_REF }}
 steps:
-  - sources:
+  - env:
+      CC: gcc-14
+      CXX: g++-14
+    sources:
       - url: https://src.fedoraproject.org/lookaside/extras/libtirpc/libtirpc-{{ .LIBTIRPC_VERSION | replace "-" "." }}.tar.bz2/sha512/df0781a74ff9ded2d3c4f5eb7e05496b9f58eac8060c02c68331dc14c4a00304dcd19f46836f5756fe0d9d27095fd463d42dd696fcdff891516711b7d63deabe/libtirpc-{{ .LIBTIRPC_VERSION | replace "-" "." }}.tar.bz2
         destination: libtirpc.tar.bz2
         sha256: {{ .LIBTIRPC_SHA256 }}

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/lts/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/lts/pkg.yaml
@@ -3,6 +3,7 @@ variant: scratch
 shell: /bin/bash
 install:
   - build-base
+  - gcc-14
   - bash
   - go
   - coreutils
@@ -33,6 +34,8 @@ steps:
         sha256: {{ .LIBNVIDIA_CONTAINER_SHA256 }}
         sha512: {{ .LIBNVIDIA_CONTAINER_SHA512 }}
     env:
+      CC: gcc-14
+      CXX: g++-14
       SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
       REVISION: {{ .LIBNVIDIA_CONTAINER_REF }}
       LIB_VERSION: {{ .LIBNVIDIA_CONTAINER_VERSION | replace "v" "" }}

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/production/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/production/pkg.yaml
@@ -3,6 +3,7 @@ variant: scratch
 shell: /bin/bash
 install:
   - build-base
+  - gcc-14
   - bash
   - go
   - coreutils
@@ -33,6 +34,8 @@ steps:
         sha256: {{ .LIBNVIDIA_CONTAINER_SHA256 }}
         sha512: {{ .LIBNVIDIA_CONTAINER_SHA512 }}
     env:
+      CC: gcc-14
+      CXX: g++-14
       SOURCE_DATE_EPOCH: {{ .BUILD_ARG_SOURCE_DATE_EPOCH }}
       REVISION: {{ .LIBNVIDIA_CONTAINER_REF }}
       LIB_VERSION: {{ .LIBNVIDIA_CONTAINER_VERSION | replace "v" "" }}

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/zlib/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-cli/zlib/pkg.yaml
@@ -3,11 +3,15 @@ variant: scratch
 shell: /bin/bash
 install:
   - build-base
+  - gcc-14
   - bash
 dependencies:
   - image: cgr.dev/chainguard/wolfi-base@{{ .WOLFI_BASE_REF }}
 steps:
-  - sources:
+  - env:
+      CC: gcc-14
+      CXX: g++-14
+    sources:
       - url: https://zlib.net/fossils/zlib-{{ .ZLIB_VERSION }}.tar.gz
         destination: zlib.tar.gz
         sha256: {{ .ZLIB_SHA256 }}

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/pkg.yaml
@@ -3,6 +3,7 @@ variant: scratch
 shell: /bin/bash
 install:
   - build-base
+  - gcc-14
   - bash
   - go
   - patch
@@ -15,6 +16,8 @@ steps:
         sha256: {{ .CONTAINER_TOOLKIT_SHA256 }}
         sha512: {{ .CONTAINER_TOOLKIT_SHA512 }}
     env:
+      CC: gcc-14
+      CXX: g++-14
       GIT_COMMIT: {{ substr 0 7 .CONTAINER_TOOLKIT_REF }} # build is using short sha
     prepare:
       - |

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/lts/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/lts/pkg.yaml
@@ -9,7 +9,10 @@ dependencies:
   # so any stage depending on nvidia-pkgs will have the updated cache
   - stage: glibc
 steps:
-  - sources:
+  - env:
+      CC: gcc-14
+      CXX: g++-14
+    sources:
     # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
       - url: https://developer.download.nvidia.com/compute/nvidia-driver/redist/nvidia_driver/linux-sbsa/nvidia_driver-linux-sbsa-{{ .NVIDIA_DRIVER_LTS_VERSION }}-archive.tar.xz
         destination: nvidia.tar.xz

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/production/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/production/pkg.yaml
@@ -9,7 +9,10 @@ dependencies:
   # so any stage depending on nvidia-pkgs will have the updated cache
   - stage: glibc
 steps:
-  - sources:
+  - env:
+      CC: gcc-14
+      CXX: g++-14
+    sources:
     # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
       - url: https://developer.download.nvidia.com/compute/nvidia-driver/redist/nvidia_driver/linux-sbsa/nvidia_driver-linux-sbsa-{{ .NVIDIA_DRIVER_PRODUCTION_VERSION }}-archive.tar.xz
         destination: nvidia.tar.xz


### PR DESCRIPTION
`libtirpc` fails to build with newer gcc-15 from wolfi-base. Pin to use `gcc-14`.

Fixes: #719