### PR TITLE
fix: glib version

### DIFF
--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -3,7 +3,7 @@ QEMU_VERSION: 10.0.2
 QEMU_SHA256: ef786f2398cb5184600f69aef4d5d691efd44576a3cff4126d38d4c6fec87759
 QEMU_SHA512: 7fda582c3845ea663aa5eda21bb38ebcfb6c25bccf8944ea6cdf8b5be6946b5a874b36674a7f5db3e325abb9cca0dd9bc0727837fdceb71a8c947d96169a9b20
 # renovate: datasource=git-tags depName=https://gitlab.gnome.org/GNOME/glib.git
-GLIB_VERSION: 2.85.1
+GLIB_VERSION: 2.85.0
 GLIB_SHA256: 97cfb0466ae41fca4fa2a57a15440bee15b54ae76a12fb3cbff11df947240e48
 GLIB_SHA512: c08dd4f8c87b4dde98a6529e136b935db459bcdf3be22ed76c6bcb6e93d374740c15899c0645cec363c72fb0d508b6365bb5f5aaa7b36b67f13748cfcd0b55ce
 # renovate: datasource=github-releases extractVersion=^pcre2-(?<version>.*)$ depName=PCRE2Project/pcre2


### PR DESCRIPTION
The version was wrong, but as the cache is shared across packages, and sha256 was correct, the correct file was picked up from the cache.