### PR TITLE
feat: add DVBSky S952 firmware driver extension

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -15,6 +15,7 @@ spec:
     - ctr
     - drbd
     - dvb-cx23885
+    - dvb-m88ds3103
     - ecr-credential-provider
     - fuse3
     - gasket-driver

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,6 +22,7 @@ If the field is marked as `Needs Maintainer`, it means that the package is curre
 | crun                                      | Henrik Gerdes      | [hegerdes](https://github.com/hegerdes)                              |
 | drbd                                      | Needs Maintainer   | NA                                                                   |
 | dvb-cx23885                               | Skyler Mäntysaari  | [samip5](https://github.com/samip5)                                  |
+| dvb-m88ds3103                             | Yehia Amer         | [yehia2amer](https://github.com/yehia2amer)                          |
 | ecr-credential-provider                   | Florian Ströger    | [Preisschild](https://github.com/Preisschild)                        |
 | fuse3                                     | Sidero Labs        | NA                                                                   |
 | gasket-driver                             | Sidero Labs        | NA                                                                   |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-06-08T13:34:39Z by kres 5f6eb2a.
+# Generated on 2025-06-15T15:55:58Z by kres 5128bc1.
 
 # common variables
 
@@ -70,6 +70,7 @@ TARGETS += crun
 TARGETS += ctr
 TARGETS += drbd
 TARGETS += dvb-cx23885
+TARGETS += dvb-m88ds3103
 TARGETS += ecr-credential-provider
 TARGETS += fuse3
 TARGETS += gasket-driver

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ cosign verify --certificate-identity-regexp '@siderolabs\.com$' --certificate-oi
 | Name                            | Image                                                                                                 | Description                                                  | Version Format  |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | --------------- |
 | [dvb-cx23885](dvb/dvb-cx23885/) | [ghcr.io/siderolabs/dvb-cx23885](https://github.com/siderolabs/extensions/pkgs/container/dvb-cx23885) | DVB kernel modules + firmware for Hauppage WinTV-quadHD PCIe | `talos version` |
+| [dvb-m88ds3103](dvb/dvb-m88ds3103/) | [ghcr.io/siderolabs/dvb-m88ds3103](https://github.com/siderolabs/extensions/pkgs/container/dvb-m88ds3103) | DVB firmware for DVBSky S952 PCIe          | `upstream version` |
 
 ### Miscellaneous
 

--- a/dvb/dvb-m88ds3103/README.md
+++ b/dvb/dvb-m88ds3103/README.md
@@ -1,0 +1,21 @@
+# DVB m88ds3103 Firmware Extension
+
+This system extension provides the `dvb-demod-m88ds3103.fw` firmware file, primarily for DVB-S/S2 PCIe cards like the DVBSky S952.
+
+## Prerequisites
+
+*   This extension only provides the firmware. It is intended to be used alongside an existing DVB driver extension (e.g., `dvb-cx23885` or a similar extension) that supplies the necessary kernel modules and drivers for your DVB hardware.
+Ensure that a compatible DVB driver extension is installed and configured on your Talos system for this firmware to be utilized.
+
+## Usage
+
+Once installed, this extension performs the following:
+
+1.  Makes the `dvb-demod-m88ds3103.fw` firmware available in the standard firmware path (`/usr/lib/firmware/`) for DVB drivers to load.
+2.  Configures the `cx23885` driver for IR support by creating `/etc/modprobe.d/cx23885.conf` with the option `enable_885_ir=1`. This is beneficial if you are using the `dvb-cx23885` extension and your hardware supports IR.
+
+## Firmware Source
+
+The `dvb-demod-m88ds3103.fw` firmware is sourced from the [OpenELEC dvb-firmware project](https://github.com/OpenELEC/dvb-firmware/blob/master/firmware/dvb-demod-m88ds3103.fw).
+
+For more general information on the DVBSky S952 card, you can check this guide: https://www.linuxtv.org/wiki/index.php/DVBSky_S952

--- a/dvb/dvb-m88ds3103/manifest.yaml
+++ b/dvb/dvb-m88ds3103/manifest.yaml
@@ -1,0 +1,11 @@
+version: v1alpha1
+metadata:
+  name: dvb-m88ds3103
+  version: "$VERSION"
+  author: Yehia Amer
+  description: |
+    This system extension provides the dvb-demod-m88ds3103.fw firmware for DVB-S/S2 PCIe cards like DVBSky S952.
+    It is intended to be used as a dependency on existing DVB driver extension dvb-cx23885 that provides the necessary kernel modules.
+  compatibility:
+    talos:
+      version: ">= v1.9.0"

--- a/dvb/dvb-m88ds3103/pkg.yaml
+++ b/dvb/dvb-m88ds3103/pkg.yaml
@@ -1,0 +1,43 @@
+name: dvb-m88ds3103
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  - stage: dvb-cx23885
+  # - image: alpine:3.18 # Using alpine as a base image
+  #   to: / # Ensure it copies to the root
+  # The pkgs version for a particular release of Talos as defined in
+  # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - sources:
+      - url: https://github.com/OpenELEC/dvb-firmware/raw/master/firmware/dvb-demod-m88ds3103.fw
+        destination: dvb-demod-m88ds3103.fw
+        sha256: 4767ab80ceba4a66315cbec2a07ae1f7ebbd19c5758fd098b932e02c9108eff9
+        sha512: 6db7c7e18a630cc0ac665f7baededb08b8ab475ef0d93590b01c4c165aef9165f9d8e0014d65b5f39a2f71e859d8865074e6143045b31ee5814f88239df4595d
+    prepare:
+      - |
+        sed -i 's#$VERSION#{{ .VERSION }}#' /pkg/manifest.yaml
+
+        mkdir -p /rootfs
+    # {{ if eq .ARCH "x86_64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+    install:
+      - |
+        mkdir -p /rootfs/usr/lib/firmware
+        cp dvb-demod-m88ds3103.fw /rootfs/usr/lib/firmware/dvb-demod-m88ds3103.fw
+
+        # Create modprobe.d directory and cx23885.conf for IR support
+        mkdir -p /rootfs/etc/modprobe.d
+        echo "options cx23885 enable_885_ir=1" > /rootfs/etc/modprobe.d/cx23885.conf
+    test:
+      - |
+        mkdir -p /extensions-validator-rootfs
+        cp -r /rootfs/ /extensions-validator-rootfs/rootfs
+        cp /pkg/manifest.yaml /extensions-validator-rootfs/manifest.yaml
+        /extensions-validator validate --rootfs=/extensions-validator-rootfs --pkg-name="${PKG_NAME}"
+    # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/dvb/dvb-m88ds3103/vars.yaml
+++ b/dvb/dvb-m88ds3103/vars.yaml
@@ -1,0 +1,1 @@
+VERSION: "{{ .BUILD_ARG_TAG }}"


### PR DESCRIPTION
feat: enhance dvb-m88ds3103 extension with IR support configuration

This system extension provides the dvb-demod-m88ds3103.fw firmware for DVB-S/S2 PCIe cards like DVBSky S952