### PR TITLE
fix: TLS Verification failures on Newt

### DIFF
--- a/network/newt/newt.yaml
+++ b/network/newt/newt.yaml
@@ -9,4 +9,12 @@ depends:
   - configuration: true
 container:
   entrypoint: /usr/local/bin/newt
+  mounts:
+  # Mount CA root certificates as the endpoints will be signed by Let's Encrypt
+  - source: /etc/ssl/certs
+    destination: /etc/ssl/certs
+    type: bind
+    options:
+      - rbind
+      - ro
 restart: always


### PR DESCRIPTION
This was an oversight from me. I didn't test it with a secure endpoint when I wrote that extension.

It fixes errors like this in the extension's logs.
```log
talos.example.ca: ERROR: 2025/07/04 16:33:50 Failed to connect: failed to get token: failed to request new token: Post "https://pangolin.example.ca/api/v1/auth/newt/get-token": tls: failed to verify certificate: x509: certificate signed by unknown authority. Retrying in 10s...
```

It is based on the work done on Tailscale in #669 which fixed #665.
I figured Tailscale was a good example since it needs to reach a public endpoint that's of course using secure connections too.