### PR TITLE
fix: nfsrahead udev rule

### DIFF
--- a/storage/nfsrahead/pkg.yaml
+++ b/storage/nfsrahead/pkg.yaml
@@ -29,28 +29,29 @@ steps:
         export CFLAGS="${CFLAGS} -I/usr/local/include"
 
         ./configure \
-          --disable-gss \
-          --disable-ipv6 \
-          --disable-mount \
-          --disable-nfsdcld \
-          --disable-nfsdctl \
-          --disable-nfsv4 \
-          --disable-nfsv41 \
-          --disable-uuid \
-          --enable-junction=no \
-          --with-nfsconfig=/usr/local/etc/nfsrahead/nfs.conf \
-          --with-rpcgen=internal \
-          --prefix=/usr/local
+            --disable-gss \
+            --disable-ipv6 \
+            --disable-mount \
+            --disable-nfsdcld \
+            --disable-nfsdctl \
+            --disable-nfsv4 \
+            --disable-nfsv41 \
+            --disable-uuid \
+            --enable-junction=no \
+            --with-nfsconfig=/usr/local/etc/nfsrahead/nfs.conf \
+            --with-rpcgen=internal \
+            --prefix=/usr/local
     build:
       - |
+        make clean
         make -C support/nfs
         make -C tools/nfsrahead
     install:
       - |
         mkdir -p /rootfs/usr/local/etc/nfsrahead
         cp /pkg/files/nfs.conf /rootfs/usr/local/etc/nfsrahead/nfs.conf
-        make -C tools/nfsrahead DESTDIR=/rootfs install
-        rm -rf /rootfs/usr/share
+        make DESTDIR=/rootfs install -C tools/nfsrahead
+        rm -rf /rootfs/usr/local/share
     test:
       - |
         mkdir -p /extensions-validator-rootfs


### PR DESCRIPTION
Upstream has the `99-nfs.rules` artifact already built, so we need to run a `make clean` to delete this file and recreate it with the correct prefix: `/usr/local`. Otherwise, the udev rule will never work because it's pointing to this binary `/usr/libexec/nfsrahead` instead of the generated one `/usr/local/libexec/nfsrahead`

+ https://github.com/siderolabs/extensions/commit/c479d91284a4f98236306d6efce1ab8a46d43a74