### PR TITLE
backport: feat: add thunderbolt udev rule

### DIFF
--- a/drivers/thunderbolt/README.md
+++ b/drivers/thunderbolt/README.md
@@ -66,3 +66,7 @@ You can also verify everything in dmesg:
  SUBSYSTEM=thunderbolt
  DEVICE=+thunderbolt:1-1
 ```
+
+## Security Warning
+
+This extension automatically authorizes all Thunderbolt devices during system boot, which poses potential security risks. Use at your own discretion.

--- a/drivers/thunderbolt/files/99-thunderbolt.rules
+++ b/drivers/thunderbolt/files/99-thunderbolt.rules
@@ -1,0 +1,2 @@
+# This will authorize Thunderbolt devices on system boot
+ACTION=="add", SUBSYSTEM=="thunderbolt", ATTR{authorized}=="0", ATTR{authorized}="1"

--- a/drivers/thunderbolt/manifest.yaml
+++ b/drivers/thunderbolt/manifest.yaml
@@ -5,7 +5,8 @@ metadata:
   author: Igor Rzegocki
   description: |
     This system extension provides Thunderbolt/USB4 drivers kernel modules built against a specific Talos version.
-    This driver enables Thunderbolt/USB4 devices, including networking.
+    It enables support for Thunderbolt/USB4 devices, including those used for networking.
+    WARNING: This extension automatically authorizes all Thunderbolt devices during system boot, which poses potential security risks. Use at your own discretion.
   compatibility:
     talos:
       version: ">= v1.5.0"

--- a/drivers/thunderbolt/pkg.yaml
+++ b/drivers/thunderbolt/pkg.yaml
@@ -18,6 +18,9 @@ steps:
 
         xargs -a /pkg/files/modules.txt -I {} install -D /usr/lib/modules/${KERNELRELEASE}/{} /rootfs/usr/lib/modules/${KERNELRELEASE}/{}
         depmod -b /rootfs/usr ${KERNELRELEASE}
+      - |
+        mkdir -p /rootfs/usr/lib/udev/rules.d/
+        cp /pkg/files/99-thunderbolt.rules /rootfs/usr/lib/udev/rules.d/
   - test:
       - |
         # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping


### PR DESCRIPTION
This will authorize devices on system boot

Fixes: https://github.com/siderolabs/extensions/issues/530



(cherry picked from commit bbea57328cfabaa3013ba4deb9f8a5b4634a21b2)