### PR TITLE
Refactor and bump talos-vmtoolsd

### DIFF
--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -15,6 +15,6 @@ XEN_GUEST_AGENT_VERSION: 5c274e651c29f92fc0c418fda486373b0f34f0da
 XEN_GUEST_AGENT_SHA256: c52f4781739e500e98a3298c9e44fe9bcbe1892c22aa6bb031d1a847123deaaa
 XEN_GUEST_AGENT_SHA512: 49bf15d7257f7fcb5ac919ca57e8c16bb6f8199684adef034bd1e7683dd9fb23a5604667fb75e27eadd02a2f9b130339409873b5720d7d3f5e4153feb5fa98ba
 # renovate: datasource=github-releases depName=siderolabs/talos-vmtoolsd
-TALOS_VMTOOLSD_VERSION: v1.1.0
+TALOS_VMTOOLSD_VERSION: v1.3.0
 # renovate: datasource=github-releases depName=siderolabs/talos-metal-agent
 TALOS_METAL_AGENT_VERSION: v0.1.3

--- a/guest-agents/vmtoolsd-guest-agent/manifest.yaml.tmpl
+++ b/guest-agents/vmtoolsd-guest-agent/manifest.yaml.tmpl
@@ -2,7 +2,7 @@ version: v1alpha1
 metadata:
   name: vmtoolsd-guest-agent
   version: "{{ .VERSION }}"
-  author: Brandon Nason
+  author: Equinix and Siderolabs
   description: |
     [{{ .TIER }}] This system extension provides talos-vmtoolsd
   compatibility:

--- a/guest-agents/vmtoolsd-guest-agent/pkg.yaml
+++ b/guest-agents/vmtoolsd-guest-agent/pkg.yaml
@@ -5,12 +5,23 @@ dependencies:
   - stage: base
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/talos-vmtoolsd:{{ .TALOS_VMTOOLSD_VERSION }}"
     from: /
-    to: /rootfs
+    to: /upstream
 steps:
+  - install:
+      - |
+        mkdir -p /rootfs/usr/local/lib/containers/talos-vmtoolsd/
+
+        cp /upstream/talos-vmtoolsd /rootfs/usr/local/lib/containers/talos-vmtoolsd/talos-vmtoolsd
+      - |
+        mkdir -p /rootfs/usr/local/etc/containers
+
+        cp /pkg/talos-vmtoolsd.yaml /rootfs/usr/local/etc/containers/
   - test:
       - |
-        cp /pkg/manifest.yaml /rootfs/manifest.yaml
-        /extensions-validator validate --rootfs=/rootfs --pkg-name="${PKG_NAME}"
+        mkdir -p /extensions-validator-rootfs
+        cp -r /rootfs /extensions-validator-rootfs/rootfs
+        cp /pkg/manifest.yaml /extensions-validator-rootfs/manifest.yaml
+        /extensions-validator validate --rootfs=/extensions-validator-rootfs --pkg-name="${PKG_NAME}"
     sbom:
       outputPath: /rootfs/usr/local/share/spdx/vmtoolsd-guest-agent.spdx.json
       version: {{ .TALOS_VMTOOLSD_VERSION }}
@@ -18,6 +29,6 @@ steps:
         - Apache-2.0
 finalize:
   - from: /rootfs
-    to: /
+    to: /rootfs
   - from: /pkg/manifest.yaml
     to: /

--- a/guest-agents/vmtoolsd-guest-agent/talos-vmtoolsd.yaml
+++ b/guest-agents/vmtoolsd-guest-agent/talos-vmtoolsd.yaml
@@ -1,0 +1,19 @@
+name: talos-vmtoolsd
+container:
+  entrypoint: ./talos-vmtoolsd
+  args:
+    - vmtoolsd
+    - --use-machined
+  mounts:
+    - source: /system/run/machined/machine.sock
+      destination: /system/run/machined/machine.sock
+      type: bind
+      options:
+        - rshared
+        - rbind
+        - rw
+depends:
+  - path: /system/run/machined/machine.sock
+  - network:
+    - addresses
+restart: always


### PR DESCRIPTION
in siderolabs/talos-vmtoolsd#42 the extension creation was dropped, this commit creates the logic in this repo