### PR TITLE
feat: zerotier - add possible custom planet file

### DIFF
--- a/network/zerotier/README.md
+++ b/network/zerotier/README.md
@@ -42,6 +42,7 @@ The extension can be configured through environment variables:
 
 - `ZEROTIER_NETWORK`: The network ID to join (required)
 - `ZEROTIER_IDENTITY_SECRET`: Optional pre-existing identity to use (format: "address:0:public:private")
+- `ZEROTIER_PLANET`: Optional pre-existing planet file encoded in base64
 
 ### Using an existing identity
 
@@ -58,3 +59,20 @@ environment:
 ```
 
 If no identity is provided, a new one will be generated automatically. (You may need to authorize this node in your Zerotier network according to your network policies before it will recieve an IP address).
+
+### Using an custom planet file
+
+If you want to specify custom planet file from a hosted planet, you can specify an custom planet:
+
+```yaml
+---
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: zerotier
+environment:
+  - ZEROTIER_NETWORK=<your network id>
+  - ZEROTIER_IDENTITY_SECRET=<identity string>
+  - ZEROTIER_PLANET=<base64 encoded planet file>
+```
+
+If no planet is provided, the public planet file from ZeroTier will be used.

--- a/network/zerotier/zerotier-wrapper/main.go
+++ b/network/zerotier/zerotier-wrapper/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"log"
@@ -20,6 +21,7 @@ import (
 const (
 	zerotierPath    = "/var/lib/zerotier-one"
 	identityPath    = "/var/lib/zerotier-one/identity.secret"
+	planetPath      = "/var/lib/zerotier-one/planet"
 	identityPubPath = "/var/lib/zerotier-one/identity.public"
 	zerotierBinPath = "/usr/local/bin/zerotier-one"
 )
@@ -38,6 +40,18 @@ func main() {
 		log.Fatalf("identity configuration failed: %v", err)
 	}
 	log.Printf("identity configured (source: %s)", identitySource)
+
+	// If ZEROTIER_PLANET env var is set, set the planet file.
+	if planet := os.Getenv("ZEROTIER_PLANET"); planet != "" {
+		planet, err := base64.StdEncoding.DecodeString(planet)
+		if err != nil {
+			log.Fatalf("failed to decode base64 planet from environment: %v", err)
+		}
+		if err := os.WriteFile(planetPath, planet, 0o644); err != nil {
+			log.Fatalf("failed to write planet file: %v", err)
+		}
+		log.Printf("custom planet file loaded")
+	}
 
 	// If ZEROTIER_NETWORK env var is set, join the network.
 	if network := os.Getenv("ZEROTIER_NETWORK"); network != "" {


### PR DESCRIPTION
Add the possibility of configuring a `planet` file for zerotier (for private roots/controller server described in https://docs.zerotier.com/roots/)