### PR TITLE
feat: update vmtoolsd to v1.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-15T16:43:11Z by kres 7918c5d-dirty.
+# Generated on 2025-09-18T12:49:25Z by kres ce14887.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.1
+        uses: kenchan0130/actions-system-info@v1.4.0
         continue-on-error: true
       - name: print-system-info
         run: |
@@ -141,7 +141,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.1
+        uses: kenchan0130/actions-system-info@v1.4.0
         continue-on-error: true
       - name: print-system-info
         run: |
@@ -199,7 +199,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.1
+        uses: kenchan0130/actions-system-info@v1.4.0
         continue-on-error: true
       - name: print-system-info
         run: |

--- a/.github/workflows/grype-scan-cron.yaml
+++ b/.github/workflows/grype-scan-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-15T16:43:11Z by kres 7918c5d-dirty.
+# Generated on 2025-09-18T12:49:25Z by kres ce14887.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.1
+        uses: kenchan0130/actions-system-info@v1.4.0
         continue-on-error: true
       - name: print-system-info
         run: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-07-15T16:36:07Z by kres b869533.
+# Generated on 2025-09-18T12:49:25Z by kres ce14887.
 
 "on":
   schedule:
@@ -15,7 +15,7 @@ jobs:
       - ubuntu-latest
     steps:
       - name: Close stale issues and PRs
-        uses: actions/stale@v9.1.0
+        uses: actions/stale@v10.0.0
         with:
           close-issue-message: This issue was closed because it has been stalled for 7 days with no activity.
           days-before-issue-close: "5"

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-15T16:41:51Z by kres 7918c5d-dirty.
+# Generated on 2025-09-18T12:49:25Z by kres ce14887.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.1
+        uses: kenchan0130/actions-system-info@v1.4.0
         continue-on-error: true
       - name: print-system-info
         run: |

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ tiers based on support level:
 | ---- | ---- | ----- | ------- | ----------- |
 | [metal-agent](guest-agents/metal-agent) | :green_square: core | [ghcr.io/siderolabs/metal-agent](https://github.com/siderolabs/extensions/pkgs/container/metal-agent) | `v0.1.3` |  This system extension provides talos-metal-agent |
 | [qemu-guest-agent](guest-agents/qemu-guest-agent) | :yellow_square: extra | [ghcr.io/siderolabs/qemu-guest-agent](https://github.com/siderolabs/extensions/pkgs/container/qemu-guest-agent) | `10.1.0` |  This system extension provides the QEMU Guest Agent service. |
-| [vmtoolsd-guest-agent](guest-agents/vmtoolsd-guest-agent) | :yellow_square: extra | [ghcr.io/siderolabs/vmtoolsd-guest-agent](https://github.com/siderolabs/extensions/pkgs/container/vmtoolsd-guest-agent) | `v1.3.0` |  This system extension provides talos-vmtoolsd |
+| [vmtoolsd-guest-agent](guest-agents/vmtoolsd-guest-agent) | :yellow_square: extra | [ghcr.io/siderolabs/vmtoolsd-guest-agent](https://github.com/siderolabs/extensions/pkgs/container/vmtoolsd-guest-agent) | `v1.4.0` |  This system extension provides talos-vmtoolsd |
 | [xen-guest-agent](guest-agents/xen-guest-agent) | :yellow_square: extra | [ghcr.io/siderolabs/xen-guest-agent](https://github.com/siderolabs/extensions/pkgs/container/xen-guest-agent) | `0.4.0-g5c274e6` |  xen-guest-agent communicates information and metrics with the Xen host. |
 
 ### NVIDIA GPU

--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -15,6 +15,6 @@ XEN_GUEST_AGENT_VERSION: 5c274e651c29f92fc0c418fda486373b0f34f0da
 XEN_GUEST_AGENT_SHA256: c52f4781739e500e98a3298c9e44fe9bcbe1892c22aa6bb031d1a847123deaaa
 XEN_GUEST_AGENT_SHA512: 49bf15d7257f7fcb5ac919ca57e8c16bb6f8199684adef034bd1e7683dd9fb23a5604667fb75e27eadd02a2f9b130339409873b5720d7d3f5e4153feb5fa98ba
 # renovate: datasource=github-releases depName=siderolabs/talos-vmtoolsd
-TALOS_VMTOOLSD_VERSION: v1.3.0
+TALOS_VMTOOLSD_VERSION: v1.4.0
 # renovate: datasource=github-releases depName=siderolabs/talos-metal-agent
 TALOS_METAL_AGENT_VERSION: v0.1.3

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -34,6 +34,7 @@ tailscale: 1.88.1
 zerotier: 1.16.0
 fuse3: 3.17.4
 nut-client: 2.8.4
+talos-vmtoolsd: 1.4.0
 """
 
 [make_deps]


### PR DESCRIPTION
This version ignores a privilege error when running with secure boot.

See https://github.com/siderolabs/talos-vmtoolsd/releases/tag/v1.4.0.