### PR TITLE
feat: add xe extension

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -65,6 +65,7 @@ spec:
     - vmtoolsd-guest-agent
     - wasmedge
     - xdma-driver
+    - xe
     - xen-guest-agent
     - youki
     - zerotier
@@ -85,11 +86,11 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.12.0-alpha.0-38-gf62ebca
+        defaultValue: v1.12.0-alpha.0-41-g661e578
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
       - name: TOOLS
-        defaultValue: v1.12.0-alpha.0-14-g916b464
+        defaultValue: v1.12.0-alpha.0-15-ge62d613
       - name: TOOLS_PREFIX
         defaultValue: ghcr.io/siderolabs
   useBldrPkgTagResolver: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-13T11:20:45Z by kres 063080a.
+# Generated on 2025-10-14T15:32:52Z by kres 063080a.
 
 # common variables
 
@@ -51,9 +51,9 @@ COMMON_ARGS += $(BUILD_ARGS)
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.12.0-alpha.0-38-gf62ebca
+PKGS ?= v1.12.0-alpha.0-41-g661e578
 PKGS_PREFIX ?= ghcr.io/siderolabs
-TOOLS ?= v1.12.0-alpha.0-14-g916b464
+TOOLS ?= v1.12.0-alpha.0-15-ge62d613
 TOOLS_PREFIX ?= ghcr.io/siderolabs
 
 # targets defines all the available targets
@@ -121,6 +121,7 @@ TARGETS += vc4
 TARGETS += vmtoolsd-guest-agent
 TARGETS += wasmedge
 TARGETS += xdma-driver
+TARGETS += xe
 TARGETS += xen-guest-agent
 TARGETS += youki
 TARGETS += zerotier

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ tiers based on support level:
 | [i915](drm/i915) | :green_square: core | [ghcr.io/siderolabs/i915](https://github.com/siderolabs/extensions/pkgs/container/i915) | `20251011-VERSION` |  This system extension provides Intel GPU microcode binaries and kernel modules. |
 | [panfrost](drm/panfrost) | :white_large_square: contrib | [ghcr.io/siderolabs/panfrost](https://github.com/siderolabs/extensions/pkgs/container/panfrost) | `20251011-VERSION` |  This system extension provides ARM Mali Midgard, Bifrost, and Valhall firmware binaries and kernel modules. |
 | [vc4](drm/vc4) | :yellow_square: extra | [ghcr.io/siderolabs/vc4](https://github.com/siderolabs/extensions/pkgs/container/vc4) | `VERSION` |  This system extension provides kernel modules for Broadcom VideoCore GPU. |
+| [xe](drm/xe) | :green_square: core | [ghcr.io/siderolabs/xe](https://github.com/siderolabs/extensions/pkgs/container/xe) | `20251011-VERSION` |  This system extension provides Intel GPU microcode binaries and kernel modules. |
 
 ### Drivers
 

--- a/drm/xe/files/modules.txt
+++ b/drm/xe/files/modules.txt
@@ -1,0 +1,4 @@
+modules.order
+modules.builtin
+modules.builtin.modinfo
+kernel/drivers/gpu/drm/xe/xe.ko

--- a/drm/xe/manifest.yaml.tmpl
+++ b/drm/xe/manifest.yaml.tmpl
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: xe
+  version: "{{ .VERSION }}"
+  author: Sidero Labs
+  description: |
+    [{{ .TIER }}] This system extension provides Intel GPU microcode binaries and kernel modules.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"

--- a/drm/xe/pkg.yaml
+++ b/drm/xe/pkg.yaml
@@ -1,0 +1,37 @@
+name: xe
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  # The pkgs version for a particular release of Talos as defined in
+  # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/linux-firmware:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - prepare:
+      - |
+        mkdir -p /rootfs
+  # {{ if eq .ARCH "x86_64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+  - install:
+      - |
+        export KERNELRELEASE=$(find /usr/lib/modules -type d -name "*-talos" -exec basename {} \+)
+
+        xargs -a /pkg/files/modules.txt -I {} install -D /usr/lib/modules/${KERNELRELEASE}/{} /rootfs/usr/lib/modules/${KERNELRELEASE}/{}
+      - |
+        mkdir -p /rootfs/usr/lib/firmware
+        cp -R -p /usr/lib/firmware/xe /rootfs/usr/lib/firmware
+  - test:
+      - |
+        # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping
+        find /rootfs/usr/lib/modules -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+      - |
+        mkdir -p /extensions-validator-rootfs
+        cp -r /rootfs/ /extensions-validator-rootfs/rootfs
+        cp /pkg/manifest.yaml /extensions-validator-rootfs/manifest.yaml
+        /extensions-validator validate --rootfs=/extensions-validator-rootfs --pkg-name="${PKG_NAME}"
+  # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/drm/xe/vars.yaml
+++ b/drm/xe/vars.yaml
@@ -1,0 +1,2 @@
+VERSION: "{{ .LINUX_FIRMWARE_VERSION }}-{{ .BUILD_ARG_TAG }}"
+TIER: "core"


### PR DESCRIPTION
With the upcoming 6.18 kernel Intel is enabling SR-IOV in the xe driver for most recent iGPUs (except Meteor/Arrow/Lunar Lake) behind a force_probe arg, so it would be nice to have the driver available. This is a mostly direct copy of the i915 extension so I left the author and tier as is