### PR TITLE
feat: add the ability to have multiple zerotier network to join

### DIFF
--- a/network/zerotier/README.md
+++ b/network/zerotier/README.md
@@ -40,7 +40,7 @@ mynode        runtime     ExtensionServiceConfig   zerotier   1
 
 The extension can be configured through environment variables:
 
-- `ZEROTIER_NETWORK`: The network ID to join (required)
+- `ZEROTIER_NETWORK`: The network ID to join (required, you can also specify multiple network by separting them with ",")
 - `ZEROTIER_IDENTITY_SECRET`: Optional pre-existing identity to use (format: "address:0:public:private")
 - `ZEROTIER_PLANET`: Optional pre-existing planet file encoded in base64
 
@@ -56,6 +56,19 @@ name: zerotier
 environment:
   - ZEROTIER_NETWORK=<your network id>
   - ZEROTIER_IDENTITY_SECRET=<identity string>
+```
+
+### Join multiple network
+
+If you want to join multiple zerotier network, you can use the following format:
+
+```yaml
+---
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: zerotier
+environment:
+  - ZEROTIER_NETWORK=<your network id 1>,<your network id 2>,<your network id 3>
 ```
 
 If no identity is provided, a new one will be generated automatically. (You may need to authorize this node in your Zerotier network according to your network policies before it will recieve an IP address).

--- a/network/zerotier/zerotier-wrapper/main.go
+++ b/network/zerotier/zerotier-wrapper/main.go
@@ -55,11 +55,13 @@ func main() {
 
 	// If ZEROTIER_NETWORK env var is set, join the network.
 	if network := os.Getenv("ZEROTIER_NETWORK"); network != "" {
-		log.Printf("joining network %s", network)
-		if err := joinNetwork(network); err != nil {
-			log.Fatalf("failed to join network: %v", err)
+		for _, network := range strings.Split(network, ",") {
+			log.Printf("joining network %s", network)
+			if err := joinNetwork(network); err != nil {
+				log.Fatalf("failed to join network: %v", err)
+			}
+			log.Printf("joined network %s", network)
 		}
-		log.Printf("joined network %s", network)
 	}
 
 	// Start zerotier-one process.


### PR DESCRIPTION
Hello,

Simple addition to be able to join multiple ZT networks.
It will not break the actual "one network" behavior, since `strings.Split` with a separator and no occurrence found will return an array of 1 with the full string in it. 

Thanks