### PR TITLE
fix: image-signer commands

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -116,6 +116,8 @@ spec:
       toplevel: true
     - name: internal/extensions/descriptions.yaml
       toplevel: true
+    - name: $(ARTIFACTS)/image-signer
+      toplevel: true
     - name: sign-images
       toplevel: true
     - name: grype-scan
@@ -211,17 +213,30 @@ spec:
         done
 ---
 kind: custom.Step
-name: sign-images
+name: $(ARTIFACTS)/image-signer
 spec:
   makefile:
     enabled: true
     phony: true
     variables:
-      - name: IMAGE_SIGNER_IMAGE
-        defaultValue: ghcr.io/siderolabs/image-signer:latest
+      - name: IMAGE_SIGNER_RELEASE
+        defaultValue: v0.1.1
     script:
       - |
-        @docker run --pull=always --rm --net=host $(IMAGE_SIGNER_IMAGE) sign --timeout=15m $(shell crane export $(EXTENSIONS_IMAGE_REF) | tar x --to-stdout image-digests) $(EXTENSIONS_IMAGE_REF)@$$(crane digest $(EXTENSIONS_IMAGE_REF))
+        @curl -sSL https://github.com/siderolabs/go-tools/releases/download/$(IMAGE_SIGNER_RELEASE)/image-signer-$(OPERATING_SYSTEM)-$(GOARCH) -o $(ARTIFACTS)/image-signer
+        @chmod +x $(ARTIFACTS)/image-signer
+---
+kind: custom.Step
+name: sign-images
+spec:
+  makefile:
+    enabled: true
+    phony: true
+    depends:
+      - $(ARTIFACTS)/image-signer
+    script:
+      - |
+        @$(ARTIFACTS)/image-signer sign --timeout=15m $(shell crane export $(EXTENSIONS_IMAGE_REF) | tar x --to-stdout image-digests) $(EXTENSIONS_IMAGE_REF)@$$(crane digest $(EXTENSIONS_IMAGE_REF))
 ---
 kind: custom.Step
 name: grype-scan

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-27T13:21:29Z by kres 46e133d.
+# Generated on 2025-10-30T03:39:23Z by kres cd5a938.
 
 # common variables
 
@@ -55,7 +55,7 @@ PKGS ?= v1.12.0-alpha.0-45-gda97c36
 PKGS_PREFIX ?= ghcr.io/siderolabs
 TOOLS ?= v1.12.0-alpha.0-16-ga08cc1f
 TOOLS_PREFIX ?= ghcr.io/siderolabs
-IMAGE_SIGNER_IMAGE ?= ghcr.io/siderolabs/image-signer:latest
+IMAGE_SIGNER_RELEASE ?= v0.1.1
 
 # targets defines all the available targets
 
@@ -260,9 +260,14 @@ internal/extensions/descriptions.yaml: internal/extensions/image-digests
 	  crane export $$image - | tar x -O --occurrence=1 manifest.yaml | yq -r ". += {\"$$image\": {\"author\": .metadata.author, \"description\": .metadata.description}} | del(.metadata, .version)" - >> internal/extensions/descriptions.yaml; \
 	done
 
+.PHONY: $(ARTIFACTS)/image-signer
+$(ARTIFACTS)/image-signer:
+	@curl -sSL https://github.com/siderolabs/go-tools/releases/download/$(IMAGE_SIGNER_RELEASE)/image-signer-$(OPERATING_SYSTEM)-$(GOARCH) -o $(ARTIFACTS)/image-signer
+	@chmod +x $(ARTIFACTS)/image-signer
+
 .PHONY: sign-images
-sign-images:
-	@docker run --pull=always --rm --net=host $(IMAGE_SIGNER_IMAGE) sign --timeout=15m $(shell crane export $(EXTENSIONS_IMAGE_REF) | tar x --to-stdout image-digests) $(EXTENSIONS_IMAGE_REF)@$$(crane digest $(EXTENSIONS_IMAGE_REF))
+sign-images: $(ARTIFACTS)/image-signer
+	@$(ARTIFACTS)/image-signer sign --timeout=15m $(shell crane export $(EXTENSIONS_IMAGE_REF) | tar x --to-stdout image-digests) $(EXTENSIONS_IMAGE_REF)@$$(crane digest $(EXTENSIONS_IMAGE_REF))
 
 .PHONY: grype-scan
 grype-scan:


### PR DESCRIPTION
Use the `image-signer` cli since we cannot pass in docker login credentials saved in keychain to `docker` container.