### PR TITLE
feat: add realtek r8127 system extension

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -34,6 +34,7 @@ spec:
     - mei
     - metal-agent
     - nebula
+    - realtek-r8127
     - newt
     - nfsd
     - nfsrahead

--- a/drivers/realtek-r8127/README.md
+++ b/drivers/realtek-r8127/README.md
@@ -1,0 +1,42 @@
+# Realtek RTL8127 10GbE Driver
+
+## Description
+
+This extension provides the Realtek RTL8127 10 Gigabit Ethernet driver for Talos Linux.
+
+## Hardware Support
+
+- **Device ID**: `10ec:8127` (Realtek RTL8127)
+- **Alternate ID**: `10ec:0e10`
+- **Speed**: 10 Gigabit Ethernet
+- **Interface**: PCIe
+
+## Tested On
+
+- NVIDIA DGX Spark (GB10 Grace Blackwell)
+
+## Features
+
+- Full PTP (Precision Time Protocol) support
+- RSS (Receive Side Scaling) support  
+- VLAN support
+- ASPM (Active State Power Management)
+- EEE (Energy Efficient Ethernet)
+
+## Installation
+
+Include this extension when generating Talos boot assets:
+
+```bash
+docker run --rm -t \
+  -v $PWD/_out:/out \
+  ghcr.io/siderolabs/imager:v1.11.0 iso \
+  --arch arm64 \
+  --system-extension-image ghcr.io/siderolabs/realtek-r8127:v1.11.0
+```
+
+## Driver Version
+
+- **r8127**: 11.015.00
+- **Source**: OpenWRT rtl8127 (https://github.com/openwrt/rtl8127)
+

--- a/drivers/realtek-r8127/manifest.yaml.tmpl
+++ b/drivers/realtek-r8127/manifest.yaml.tmpl
@@ -1,0 +1,13 @@
+version: v1alpha1
+metadata:
+  name: realtek-r8127
+  version: "{{ .VERSION }}"
+  author: Sidero Labs
+  description: |
+    [{{ .TIER }}] This system extension provides the Realtek RTL8127 10GbE ethernet driver kernel module.
+    This driver is required for NVIDIA DGX Spark and other systems with Realtek RTL8127 10 Gigabit Ethernet controllers (PCI ID 10ec:8127).
+    The module is built with full PTP (Precision Time Protocol) and RSS (Receive Side Scaling) support.
+  compatibility:
+    talos:
+      version: ">= v1.9.0"
+

--- a/drivers/realtek-r8127/pkg.yaml
+++ b/drivers/realtek-r8127/pkg.yaml
@@ -1,0 +1,23 @@
+name: realtek-r8127
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/r8127-pkg:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - install:
+      - |
+        mkdir -p /rootfs/usr/lib/modules
+        cp -R /usr/lib/modules/* /rootfs/usr/lib/modules
+  - test:
+      - |
+        mkdir -p /extensions-validator-rootfs
+        cp -r /rootfs/ /extensions-validator-rootfs/rootfs
+        cp /pkg/manifest.yaml /extensions-validator-rootfs/manifest.yaml
+        /extensions-validator validate --rootfs=/extensions-validator-rootfs --pkg-name="${PKG_NAME}"
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /
+

--- a/drivers/realtek-r8127/vars.yaml
+++ b/drivers/realtek-r8127/vars.yaml
@@ -1,0 +1,3 @@
+VERSION: "11.015.00-{{ .BUILD_ARG_TAG }}"
+TIER: "community"
+


### PR DESCRIPTION
Add realtek-r8127 system extension providing RTL8127 10 Gigabit
Ethernet driver for NVIDIA DGX Spark and compatible systems.

Related to:

- https://github.com/siderolabs/talos/issues/12170
- https://github.com/siderolabs/pkgs/pull/1367

Signed-off-by: Mykhailo Marynenko <mykhailo@0x77.dev>
