### PR TITLE
feat(thunderbolt): disable auto power management

### DIFF
--- a/drivers/thunderbolt/README.md
+++ b/drivers/thunderbolt/README.md
@@ -70,3 +70,11 @@ You can also verify everything in dmesg:
 ## Security Warning
 
 This extension automatically authorizes all Thunderbolt devices during system boot, which poses potential security risks. Use at your own discretion.
+
+## Power Management
+
+This extension automatically disabled power savings on all Thunderbolt ports, if you would like to re-enable that use the following udev rule in your machineconfig.
+
+```
+ACTION=="add", SUBSYSTEM=="thunderbolt", ATTR{power/control}="auto"
+```

--- a/drivers/thunderbolt/files/99-thunderbolt.rules
+++ b/drivers/thunderbolt/files/99-thunderbolt.rules
@@ -1,2 +1,2 @@
-# This will authorize Thunderbolt devices on system boot
-ACTION=="add", SUBSYSTEM=="thunderbolt", ATTR{authorized}=="0", ATTR{authorized}="1"
+# This will authorize and disable power management for Thunderbolt devices on system boot 
+ACTION=="add", SUBSYSTEM=="thunderbolt", ATTR{authorized}=="0", ATTR{authorized}="1", ATTR{power/control}="on"


### PR DESCRIPTION
Hi 👋 

I bet most people who enable this extension are using Thunderbolt in a manner that requires it to always be on and not have type of "auto" power mode where it could be turned on or off to save power.

For me, I am running into issues with using thunderbolt for a Ceph ring and I've noticed every so often that the thunderbolt interfaces on other nodes are dropped when I reboot another which requires me to replug the thunderbolt cable or reboot my cluster nodes. While I am not 100% sure this change will fix my issue, I think most people using TB (like myself) would want to eliminate any power-saving features and reduce any external factors when thunderbolt is misbehaving.

It would be great if the thunderbolt extension could include this by default, since infrastructure/server use cases generally need stable, always-on connectivity rather than power-saving behavior.

I tested this by added a udev rule to my machine config:

```yaml
udev:
  rules:
    - # Thunderbolt - Disable Power Management
      ACTION=="add", SUBSYSTEM=="thunderbolt", ATTR{power/control}="on"
```

and running the following command...

Before:

```
❯ talosctl -n k8s-0 read /sys/bus/thunderbolt/devices/0-0/power/control
auto
```

After:

```
❯ talosctl -n k8s-0 read /sys/bus/thunderbolt/devices/0-0/power/control
on
```