### PR TITLE
fix: video4linux persistent udev rules

### DIFF
--- a/drivers/v4l-uvc/pkg.yaml
+++ b/drivers/v4l-uvc/pkg.yaml
@@ -7,14 +7,21 @@ dependencies:
   # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
 steps:
+  - sources:
+      - url: https://raw.githubusercontent.com/systemd/systemd/refs/tags/{{ .SYSTEMD_VERSION_TAG }}/rules.d/60-persistent-v4l.rules
+        destination: 60-persistent-v4l.rules
+        sha256: {{ .UDEV_RULE_SHA256 }}
+        sha512: {{ .UDEV_RULE_SHA512 }}
   - install:
       - |
         export KERNELRELEASE=$(find /usr/lib/modules -type d -name "*-talos" -exec basename {} \+)
 
         mkdir -p /rootfs
+         mkdir -p /rootfs/usr/lib/udev/rules.d/
 
         xargs -a /pkg/files/modules.txt -I {} install -D /usr/lib/modules/${KERNELRELEASE}/{} /rootfs/usr/lib/modules/${KERNELRELEASE}/{}
         depmod -b /rootfs/usr ${KERNELRELEASE}
+        cp 60-persistent-v4l.rules /rootfs/usr/lib/udev/rules.d/
   - test:
       - |
         # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping

--- a/drivers/vars.yaml
+++ b/drivers/vars.yaml
@@ -1,0 +1,4 @@
+# The version of the systemd repo to take udev rules from https://github.com/systemd/systemd
+SYSTEMD_VERSION_TAG: "v258.2"
+UDEV_RULE_SHA256: d5a6c72c7c3a50e251f74c15672a47f63674aa12eda64086a7daffa49c4c55f8
+UDEV_RULE_SHA512: b9f6f98200cddb0747f87cc552693afd84588e55758fb0f9ade110ca388770e0311f116a71d9d7a132ade6c6825fc2b1d8d2554514634b27a4266d65159c1bb2


### PR DESCRIPTION
The udev rules for v4l devices are removed from the Talos `systemd-udev` package in https://github.com/siderolabs/pkgs/blob/main/systemd-udevd/pkg.yaml#L33. This commit adds persistent udev rules as part of the `v4l-uvc-drivers` system extension to mount devices in the expected way.

Issue #863