### PR TITLE
fix: video4linux persistent udev rules

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-01T17:25:51Z by kres faf91e3.
+# Generated on 2025-11-13T15:52:54Z by kres e1d6dac.
 
 policies:
   - type: commit
@@ -12,7 +12,7 @@ policies:
           gitHubOrganization: siderolabs
       spellcheck:
         locale: US
-      maximumOfOneCommit: true
+      maximumOfOneCommit: false
       header:
         length: 89
         imperative: true

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -97,6 +97,12 @@
             "matchPackageNames": [
                 "git://linux-nfs.org/~steved/libtirpc"
             ]
+        },
+        {
+            "versioning": "regex:^(?<major>\\d+)\\.?(?<minor>\\d+)?\\.?(?<patch>\\d+)?$",
+            "matchPackageNames": [
+                "systemd/systemd"
+            ]
         }
     ],
     "separateMajorMinor": false

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -293,3 +293,6 @@ spec:
     - matchPackageNames:
         - git://linux-nfs.org/~steved/libtirpc
       versioning: 'regex:^(?<major>\d+)-(?<minor>\d+)-?(?<patch>\d+)?$'
+    - matchPackageNames:
+        - systemd/systemd
+      versioning: 'regex:^(?<major>\d+)\.?(?<minor>\d+)?\.?(?<patch>\d+)?$'

--- a/drivers/v4l-uvc/pkg.yaml
+++ b/drivers/v4l-uvc/pkg.yaml
@@ -7,14 +7,21 @@ dependencies:
   # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
 steps:
+  - sources:
+      - url: https://raw.githubusercontent.com/systemd/systemd/refs/tags/v{{ .SYSTEMD_VERSION }}/rules.d/60-persistent-v4l.rules
+        destination: 60-persistent-v4l.rules
+        sha256: {{ .SYSTEMD_SHA256 }}
+        sha512: {{ .SYSTEMD_SHA512 }}
   - install:
       - |
         export KERNELRELEASE=$(find /usr/lib/modules -type d -name "*-talos" -exec basename {} \+)
 
         mkdir -p /rootfs
+         mkdir -p /rootfs/usr/lib/udev/rules.d/
 
         xargs -a /pkg/files/modules.txt -I {} install -D /usr/lib/modules/${KERNELRELEASE}/{} /rootfs/usr/lib/modules/${KERNELRELEASE}/{}
         depmod -b /rootfs/usr ${KERNELRELEASE}
+        cp 60-persistent-v4l.rules /rootfs/usr/lib/udev/rules.d/
   - test:
       - |
         # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping

--- a/drivers/vars.yaml
+++ b/drivers/vars.yaml
@@ -1,0 +1,4 @@
+# renovate: datasource=github-releases extractVersion=^v(?<version>.*)$ depName=systemd/systemd
+SYSTEMD_VERSION: 258.2
+SYSTEMD_SHA256: d5a6c72c7c3a50e251f74c15672a47f63674aa12eda64086a7daffa49c4c55f8
+SYSTEMD_SHA512: b9f6f98200cddb0747f87cc552693afd84588e55758fb0f9ade110ca388770e0311f116a71d9d7a132ade6c6825fc2b1d8d2554514634b27a4266d65159c1bb2


### PR DESCRIPTION
The udev rules for v4l devices are removed from the Talos `systemd-udev` package in https://github.com/siderolabs/pkgs/blob/main/systemd-udevd/pkg.yaml#L33. This commit adds persistent udev rules as part of the `v4l-uvc-drivers` system extension to mount devices in the expected way.

Issue #863


Created in favor of https://github.com/siderolabs/extensions/pull/880 since can;t merge from a org 