### PR TITLE
fix: disable soci-snapshotter extension

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -53,7 +53,6 @@ spec:
     - qlogic-firmware
     - realtek-firmware
     - revpi-firmware
-    - soci-snapshotter
     - spin
     - stargz-snapshotter
     - tailscale

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-11-12T17:46:46Z by kres 911d166.
+# Generated on 2025-11-14T09:20:25Z by kres e1d6dac.
 
 # common variables
 
@@ -110,7 +110,6 @@ TARGETS += qemu-guest-agent
 TARGETS += qlogic-firmware
 TARGETS += realtek-firmware
 TARGETS += revpi-firmware
-TARGETS += soci-snapshotter
 TARGETS += spin
 TARGETS += stargz-snapshotter
 TARGETS += tailscale


### PR DESCRIPTION
It's broken:

```
[  717.387264] [talos] service[ext-soci-snapshotter](Running): Started task ext-soci-snapshotter (PID 12445) for container ext-soci-snapshotter
[  717.399174] [talos] service[ext-soci-snapshotter](Waiting): Error running Containerd(ext-soci-snapshotter), going to restart forever: task "ext-soci-snapshotter" failed: exit code 255 (last log "exec ./soci-snapshotter-grpc: no such file or directory")
```