### PR TITLE
feat: add gpio-pinctrl extension for Intel Apollo Lake

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,10 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-29T14:13:04Z by kres b5ca957.
+# Generated on 2025-11-25T14:31:25Z by kres e1d6dac.
 
 *
 !CHANGELOG.md
 !MAINTAINERS.md
 !README.md
+!gpio-extension-implementation.md
 !pkg.yaml

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -19,6 +19,7 @@ spec:
     - ecr-credential-provider
     - fuse3
     - gasket-driver
+    - gpio-pinctrl
     - glibc
     - gvisor
     - gvisor-debug

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-11-15T05:31:19Z by kres e1d6dac.
+# Generated on 2025-11-25T14:31:25Z by kres e1d6dac.
 
 # common variables
 
@@ -76,6 +76,7 @@ TARGETS += dvb-m88ds3103
 TARGETS += ecr-credential-provider
 TARGETS += fuse3
 TARGETS += gasket-driver
+TARGETS += gpio-pinctrl
 TARGETS += glibc
 TARGETS += gvisor
 TARGETS += gvisor-debug

--- a/drivers/gpio-pinctrl/README.md
+++ b/drivers/gpio-pinctrl/README.md
@@ -1,0 +1,73 @@
+# gpio-pinctrl extension
+
+This extension provides Intel GPIO/Pinctrl drivers for Apollo Lake platforms.
+
+## Installation
+
+See [Installing Extensions](https://github.com/siderolabs/extensions#installing-extensions).
+
+## Included Modules
+
+- `pinctrl-intel` - Intel pinctrl core driver
+- `pinctrl-broxton` - Intel Apollo Lake (Broxton) pinctrl driver
+
+## Usage
+
+Enable the modules in your machine configuration:
+
+```yaml
+machine:
+  kernel:
+    modules:
+      - name: pinctrl-intel
+      - name: pinctrl-broxton
+```
+
+## Verification
+
+Check that modules are loaded:
+
+```bash
+talosctl -n <node-ip> read /proc/modules | grep pinctrl
+```
+
+Expected output:
+```
+pinctrl_broxton 24576 0 - Live 0x...
+pinctrl_intel 40960 1 pinctrl_broxton, Live 0x...
+```
+
+Verify GPIO devices are available:
+
+```bash
+talosctl -n <node-ip> ls -la /dev/gpiochip*
+```
+
+Check dmesg for driver initialization:
+
+```bash
+talosctl -n <node-ip> dmesg | grep -i 'pinctrl.*INT3452'
+```
+
+## Testing with libgpiod
+
+From a privileged pod with `/dev` mounted:
+
+```bash
+gpiodetect
+gpioinfo
+```
+
+## Troubleshooting
+
+### Module not loading
+
+Ensure the extension is properly installed and the modules are listed in your machine config.
+
+### No /dev/gpiochip* devices
+
+Verify Talos is running a kernel built with `CONFIG_GPIO_CDEV=y`. Check dmesg for pinctrl driver initialization messages.
+
+### ABI/signature errors
+
+Ensure the extension was built against the same kernel version as your Talos installation.

--- a/drivers/gpio-pinctrl/files/modules.txt
+++ b/drivers/gpio-pinctrl/files/modules.txt
@@ -1,0 +1,5 @@
+modules.order
+modules.builtin
+modules.builtin.modinfo
+kernel/drivers/pinctrl/intel/pinctrl-intel.ko
+kernel/drivers/pinctrl/intel/pinctrl-broxton.ko

--- a/drivers/gpio-pinctrl/manifest.yaml.tmpl
+++ b/drivers/gpio-pinctrl/manifest.yaml.tmpl
@@ -1,0 +1,12 @@
+version: v1alpha1
+metadata:
+  name: gpio-pinctrl
+  version: "{{ .VERSION }}"
+  author: autops
+  description: |
+    [{{ .TIER }}] Intel Apollo Lake GPIO/Pinctrl drivers.
+    Provides pinctrl-intel and pinctrl-broxton kernel modules for GPIO access
+    on Intel Apollo Lake platforms (INT3452 ACPI device).
+  compatibility:
+    talos:
+      version: ">= v1.11.0"

--- a/drivers/gpio-pinctrl/pkg.yaml
+++ b/drivers/gpio-pinctrl/pkg.yaml
@@ -1,0 +1,31 @@
+name: gpio-pinctrl
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  # The pkgs version for a particular release of Talos as defined in
+  # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - install:
+      - |
+        export KERNELRELEASE=$(find /usr/lib/modules -type d -name "*-talos" -exec basename {} \+)
+
+        mkdir -p /rootfs
+
+        xargs -a /pkg/files/modules.txt -I {} install -D /usr/lib/modules/${KERNELRELEASE}/{} /rootfs/usr/lib/modules/${KERNELRELEASE}/{}
+        depmod -b /rootfs/usr ${KERNELRELEASE}
+  - test:
+      - |
+        # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping
+        find /rootfs/usr/lib/modules -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+      - |
+        mkdir -p /extensions-validator-rootfs
+        cp -r /rootfs/ /extensions-validator-rootfs/rootfs
+        cp /pkg/manifest.yaml /extensions-validator-rootfs/manifest.yaml
+        /extensions-validator validate --rootfs=/extensions-validator-rootfs --pkg-name="${PKG_NAME}"
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/drivers/gpio-pinctrl/vars.yaml
+++ b/drivers/gpio-pinctrl/vars.yaml
@@ -1,0 +1,2 @@
+VERSION: "{{ .BUILD_ARG_TAG }}"
+TIER: "extra"


### PR DESCRIPTION
## Summary
Add `gpio-pinctrl` extension that provides Intel GPIO/Pinctrl kernel modules for Apollo Lake platforms:
- `pinctrl-intel.ko` - Intel pinctrl core driver
- `pinctrl-broxton.ko` - Intel Apollo Lake (Broxton) pinctrl driver

## Use Case
Enable GPIO access on Intel Apollo Lake platforms (INT3452 ACPI device), such as the Mitac MB1 industrial board. This allows hardware control applications to interact with GPIO pins from userspace using libgpiod via `/dev/gpiochip*` devices.

## Dependencies
This extension requires kernel config options enabled in siderolabs/pkgs:
- **PR:** https://github.com/siderolabs/pkgs/pull/1378

## Usage
```yaml
machine:
  install:
    extensions:
      - image: ghcr.io/siderolabs/gpio-pinctrl:<version>
  kernel:
    modules:
      - name: pinctrl-intel
      - name: pinctrl-broxton
```

## Test Plan
- [x] Extension builds successfully
- [x] Contains correctly signed kernel modules
- [x] Passes extension-validator checks
- [ ] Modules load on Apollo Lake hardware
- [ ] `/dev/gpiochip*` devices created
- [ ] GPIO access works via libgpiod