### PR TITLE
fix: nvidia persistenced on arm64

### DIFF
--- a/nvidia-gpu/nvidia-container-toolkit/lts/nvidia-persistenced.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/lts/nvidia-persistenced.yaml
@@ -19,6 +19,13 @@ container:
         - bind
         - ro
     # shared libraries
+    - source: /lib
+      destination: /lib
+      type: bind
+      options:
+        - bind
+        - ro
+    # shared libraries
     - source: /usr/local/glibc
       destination: /usr/local/glibc
       type: bind


### PR DESCRIPTION
This is more a band-aid fix, amd64 worked since `/lib64` was mounted up.

Proper fix will be part of refactoring extension services as part of #876