### PR TITLE
chore: update to 1.13 tags

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -91,11 +91,11 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.12.0-6-gcd63cf9
+        defaultValue: v1.13.0-alpha.0
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
       - name: TOOLS
-        defaultValue: v1.12.0-1-g188885e
+        defaultValue: v1.13.0-alpha.0
       - name: TOOLS_PREFIX
         defaultValue: ghcr.io/siderolabs
   useBldrPkgTagResolver: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-11-27T15:58:33Z by kres e1d6dac.
+# Generated on 2025-11-28T13:46:31Z by kres e1d6dac.
 
 # common variables
 
@@ -51,9 +51,9 @@ COMMON_ARGS += $(BUILD_ARGS)
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.12.0-6-gcd63cf9
+PKGS ?= v1.13.0-alpha.0
 PKGS_PREFIX ?= ghcr.io/siderolabs
-TOOLS ?= v1.12.0-1-g188885e
+TOOLS ?= v1.13.0-alpha.0
 TOOLS_PREFIX ?= ghcr.io/siderolabs
 IMAGE_SIGNER_RELEASE ?= v0.1.1
 


### PR DESCRIPTION
Update tags on main to point to tools/pkgs from v1.13.0-alpha.0 tags.