### PR TITLE
chore: update ctr version to 2.2.0

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  CONTAINERD_VERSION: v2.1.5 # update this when updating PKGS_VERSION in Makefile
+  CONTAINERD_VERSION: v2.2.0 # update this when updating PKGS_VERSION in Makefile
   LINUX_FIRMWARE_VERSION: "20251125" # update this when updating PKGS_VERSION in Makefile
   DRBD_DRIVER_VERSION: 9.2.16 # update this when updating PKGS_VERSION in Makefile
   ZFS_DRIVER_VERSION: 2.4.0-rc2 # update this when updating PKGS_VERSION in Makefile

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ tiers based on support level:
 
 | Name | Tier | Image | Version | Description |
 | ---- | ---- | ----- | ------- | ----------- |
-| [ctr](tools/ctr) | :green_square: core | [ghcr.io/siderolabs/ctr](https://github.com/siderolabs/extensions/pkgs/container/ctr) | `v2.1.5` |  This extension provides ctr containerd helper binary |
+| [ctr](tools/ctr) | :green_square: core | [ghcr.io/siderolabs/ctr](https://github.com/siderolabs/extensions/pkgs/container/ctr) | `v2.2.0` |  This extension provides ctr containerd helper binary |
 | [nvme-cli](tools/nvme-cli) | :white_large_square: contrib | [ghcr.io/siderolabs/nvme-cli](https://github.com/siderolabs/extensions/pkgs/container/nvme-cli) | `v2.14` |  This system extension provides the NVMe command line interface. |
 | [util-linux-tools](tools/util-linux) | :white_large_square: contrib | [ghcr.io/siderolabs/util-linux-tools](https://github.com/siderolabs/extensions/pkgs/container/util-linux-tools) | `2.41.2` |  This system extension provides a minimal util-linux package. |
 

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -6,7 +6,7 @@ github_repo = "siderolabs/extensions"
 match_deps = "^github.com/((talos-systems|siderolabs)/[a-zA-Z0-9-]+)$"
 
 # previous release
-previous = "v1.11.0"
+previous = "v1.12.0"
 
 pre_release = true
 
@@ -19,39 +19,7 @@ See [Talos Linux documentation](https://www.talos.dev/v1.11/talos-guides/configu
     [notes.updates]
         title = "Component Updates"
         description = """\
-Amazon ENA: 2.16.0
-NVIDIA LTS: 580.95.05
-NVIDIA Production: 570.195.03
-NVIDIA Container Toolkit: 1.18.0
-ctr: 2.1.5
-crun: 1.25.1
-drbd: 9.2.16
-ecr-credential-provider: 1.34.1
-soci-snapshotter: v0.12.0
-fuse3: 3.17.4
-gvisor: 20251118.0
-hailort: 4.23.0
-kata-containers: 3.23.0
-lldpd: 1.0.20
-cloudflared: 2025.11.1
-nebula: 1.9.7
-netbird: 0.60.2
-newt: 1.6.0
-nut-client: 2.8.4
-qemu: 10.1.2
-spin: 0.22.0
-stargz-snapshotter: 0.18.1
-tailscale: 1.90.9
-talos-vmtoolsd: 1.4.0
-youki: 0.5.7
-zerotier: 1.16.0
-zfs: 2.4.0-rc2
-linux-firmware: 20251111
-tenstorrent: 2.5.0
-mdadm: 4.4
-Intel u-code: 20251111
-
-wolfi-base: sha256:42012fa027adc864efbb7cf68d9fc575ea45fe1b9fb0d16602e00438ce3901b1
+ctr: 2.2.0
 """
 
 [make_deps]


### PR DESCRIPTION
In `main`, pkgs contains `containerd` 2.2.0.