### PR TITLE
fix: add `mc.ko` to usb-audio-drivers

### DIFF
--- a/drivers/usb-audio-drivers/files/modules-aarch64.txt
+++ b/drivers/usb-audio-drivers/files/modules-aarch64.txt
@@ -1,6 +1,7 @@
 modules.order
 modules.builtin
 modules.builtin.modinfo
+kernel/drivers/media/mc/mc.ko
 kernel/sound/soundcore.ko
 kernel/sound/core/snd.ko
 kernel/sound/core/snd-pcm.ko

--- a/drivers/usb-audio-drivers/files/modules-x86_64.txt
+++ b/drivers/usb-audio-drivers/files/modules-x86_64.txt
@@ -1,6 +1,7 @@
 modules.order
 modules.builtin
 modules.builtin.modinfo
+kernel/drivers/media/mc/mc.ko
 kernel/sound/soundcore.ko
 kernel/sound/core/snd.ko
 kernel/sound/core/snd-pcm.ko


### PR DESCRIPTION
Without it, you are unable to load snd-usb-audio:

```
snd_usb_audio: Unknown symbol media_devnode_remove (err -2)
snd_usb_audio: Unknown symbol __media_device_register (err -2)
snd_usb_audio: Unknown symbol media_create_intf_link (err -2)
[..]
```

I hope this can be ported to v1.12, as v1.12-beta.1 has this "bug".