### PR TITLE
Save Netbird config to a persistent location

### DIFF
--- a/network/netbird/netbird.yaml
+++ b/network/netbird/netbird.yaml
@@ -17,7 +17,7 @@ container:
     - NB_LOG_FILE=console,/var/log/netbird/client.log
     - NB_DISABLE_PROFILES=true
     - USER=talos
-    - NB_CONFIG=/var/run/netbird/config.json
+    - NB_CONFIG=/var/lib/netbird/config.json
     - HOME=/var/run/netbird
     - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
   security:


### PR DESCRIPTION
By default the extensions stores the config on the /var/run folder which does not persist across reboots. This causes peers to be newly created. 

This commit changes the location to /var/lib and therefore not creating a new peer. 