### PR TITLE
fix(multipath-tools): add /run/udev mount for device enumeration

### DIFF
--- a/storage/multipath-tools/multipathd.yaml
+++ b/storage/multipath-tools/multipathd.yaml
@@ -42,6 +42,13 @@ container:
       options:
         - bind
         - rw
+    # udev database for device enumeration
+    - source: /run/udev
+      destination: /run/udev
+      type: bind
+      options:
+        - bind
+        - ro
 depends:
   - network:
       - addresses


### PR DESCRIPTION
## Summary

Adds the missing /run/udev mount to the multipathd container, fixing device enumeration failures.

This issue was discovered during the discussion in #946, where I was troubleshooting "spurious uevent, path not found" errors. While investigating, I found that the root cause was not the commented `configuration: true` line (which is intentional per @frezbo), but rather a missing mount.

## Problem

multipathd logs show "spurious uevent, path not found" errors for all devices, and no multipath maps are created in /dev/mapper/.

## Root Cause

multipathd uses libudev's udev_enumerate_scan_devices() during initialization (see discovery.c) to discover block devices. This function reads from /run/udev/data/ to enumerate initialized devices.

Without /run/udev mounted:
1. path_discovery() returns no devices because enumeration fails
2. The internal pathvec stays empty
3. Uevents still arrive via netlink, which works without /run/udev
4. find_path_by_dev() in main.c cannot find paths in the empty pathvec
5. This results in "spurious uevent, path not found" errors

## Investigation

I verified inside the container using talosctl:

- /etc/multipath.conf is correctly mounted with custom config
- /dev is accessible and shows the expected devices (sdc, sdd, sde, sdf)
- /sys is accessible and sysfs attributes like vendor, model, and wwid are readable
- /run/udev is missing. Only multipathd.pid and multipathd.socket exist in /run

```
$ talosctl ls /proc/<pid>/root/run/
.
multipathd.pid
multipathd.socket
```

The udev database at /run/udev/data/ is not available to the container.

## Fix

Add /run/udev as a read-only bind mount to multipathd.yaml.

## References

- https://github.com/openSUSE/multipath-tools/blob/master/libmultipath/discovery.c
- https://man7.org/linux/man-pages/man3/libudev.3.html
- Discussion in #946