### PR TITLE
chore: update dependencies

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -96,11 +96,11 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.13.0-alpha.0-42-ga63c227
+        defaultValue: v1.13.0-alpha.0-44-gdc737a6
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
       - name: TOOLS
-        defaultValue: v1.13.0-alpha.0-11-g0281af0
+        defaultValue: v1.13.0-alpha.0-12-gca26e1c
       - name: TOOLS_PREFIX
         defaultValue: ghcr.io/siderolabs
   useBldrPkgTagResolver: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-01-29T12:43:12Z by kres 1b0dcb3.
+# Generated on 2026-02-02T14:58:54Z by kres dc032d7.
 
 # common variables
 
@@ -53,9 +53,9 @@ COMMON_ARGS += $(BUILD_ARGS)
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.13.0-alpha.0-42-ga63c227
+PKGS ?= v1.13.0-alpha.0-44-gdc737a6
 PKGS_PREFIX ?= ghcr.io/siderolabs
-TOOLS ?= v1.13.0-alpha.0-11-g0281af0
+TOOLS ?= v1.13.0-alpha.0-12-gca26e1c
 TOOLS_PREFIX ?= ghcr.io/siderolabs
 IMAGE_SIGNER_RELEASE ?= v0.1.1
 


### PR DESCRIPTION
Update the following dependencies
* tools v1.13.0-alpha.0-11-g0281af0 -> v1.13.0-alpha.0-12-gca26e1c
* pkgs v1.13.0-alpha.0-42-ga63c227 -> v1.13.0-alpha.0-44-gdc737a6

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
