### PR TITLE
chore: bump metal-agent version to v0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ tiers based on support level:
 
 | Name | Tier | Image | Version | Description |
 | ---- | ---- | ----- | ------- | ----------- |
-| [metal-agent](guest-agents/metal-agent) | :green_square: core | [ghcr.io/siderolabs/metal-agent](https://github.com/siderolabs/extensions/pkgs/container/metal-agent) | `v0.1.3` |  This system extension provides talos-metal-agent |
+| [metal-agent](guest-agents/metal-agent) | :green_square: core | [ghcr.io/siderolabs/metal-agent](https://github.com/siderolabs/extensions/pkgs/container/metal-agent) | `v0.1.4` |  This system extension provides talos-metal-agent |
 | [qemu-guest-agent](guest-agents/qemu-guest-agent) | :yellow_square: extra | [ghcr.io/siderolabs/qemu-guest-agent](https://github.com/siderolabs/extensions/pkgs/container/qemu-guest-agent) | `10.2.0` |  This system extension provides the QEMU Guest Agent service. |
 | [vmtoolsd-guest-agent](guest-agents/vmtoolsd-guest-agent) | :yellow_square: extra | [ghcr.io/siderolabs/vmtoolsd-guest-agent](https://github.com/siderolabs/extensions/pkgs/container/vmtoolsd-guest-agent) | `v1.5.0` |  This system extension provides talos-vmtoolsd |
 | [xen-guest-agent](guest-agents/xen-guest-agent) | :yellow_square: extra | [ghcr.io/siderolabs/xen-guest-agent](https://github.com/siderolabs/extensions/pkgs/container/xen-guest-agent) | `0.4.0-g5c274e6` |  xen-guest-agent communicates information and metrics with the Xen host. |

--- a/guest-agents/vars.yaml
+++ b/guest-agents/vars.yaml
@@ -17,4 +17,4 @@ XEN_GUEST_AGENT_SHA512: 49bf15d7257f7fcb5ac919ca57e8c16bb6f8199684adef034bd1e768
 # renovate: datasource=github-releases depName=siderolabs/talos-vmtoolsd
 TALOS_VMTOOLSD_VERSION: v1.5.0
 # renovate: datasource=github-releases depName=siderolabs/talos-metal-agent
-TALOS_METAL_AGENT_VERSION: v0.1.3
+TALOS_METAL_AGENT_VERSION: v0.1.4

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -37,6 +37,7 @@ cloudflared: 2026.1.1
 nebula: 1.10.2
 tailscale: 1.92.5
 vmtoolsd-guest-agent: 1.5.0
+metal-agent: 0.1.4
 """
 
 [make_deps]


### PR DESCRIPTION
See https://github.com/siderolabs/talos-metal-agent/releases/tag/v0.1.4.