### PR TITLE
fix: iscsi and rpcbind extensions

### DIFF
--- a/storage/iscsi-tools/iscsid.yaml
+++ b/storage/iscsi-tools/iscsid.yaml
@@ -8,7 +8,7 @@ depends:
        - etcfiles
   - path: /etc/iscsi/initiatorname.iscsi
 container:
-  entrypoint: /sbin/iscsid
+  entrypoint: /usr/local/sbin/iscsid
   args:
     - -f
   security:

--- a/storage/iscsi-tools/pkg.yaml
+++ b/storage/iscsi-tools/pkg.yaml
@@ -46,7 +46,7 @@ steps:
           -Disns=disabled \
           -Dhomedir=/etc/iscsi \
           -Dprefix=/usr/local/lib/containers/iscsid \
-          -Discsi_sbindir=/usr/local/lib/containers/iscsid/sbin \
+          -Discsi_sbindir=/usr/local/lib/containers/iscsid/usr/local/sbin \
           -Drulesdir=/usr/lib/udev/rules.d \
           output
 

--- a/storage/nfs-utils/rpcbind/rpcbind.yaml
+++ b/storage/nfs-utils/rpcbind/rpcbind.yaml
@@ -7,7 +7,7 @@ depends:
       - hostname
       - etcfiles
 container:
-  entrypoint: /usr/local/sbin/rpcbind
+  entrypoint: /sbin/rpcbind
   args:
     - -f
     - -w


### PR DESCRIPTION
SideroLabs kubelet image expects `iscsiadm` at `/usr/local/sbin`, easier to fix here than updating kubelet image.