### PR TITLE
feat: add ipheth to usb-modem-drivers extension

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -99,7 +99,7 @@ spec:
       - name: EXTENSIONS_IMAGE_REF
         defaultValue: $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
       - name: PKGS
-        defaultValue: v1.13.0-alpha.0-61-g3c982f8
+        defaultValue: v1.13.0-alpha.0-63-g830fbac
       - name: PKGS_PREFIX
         defaultValue: ghcr.io/siderolabs
       - name: TOOLS

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-02-24T08:40:03Z by kres 6458cfd.
+# Generated on 2026-02-27T17:05:53Z by kres 6458cfd.
 
 # common variables
 
@@ -54,7 +54,7 @@ COMMON_ARGS += $(BUILD_ARGS)
 # extra variables
 
 EXTENSIONS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/extensions:$(TAG)
-PKGS ?= v1.13.0-alpha.0-60-gd065c59
+PKGS ?= v1.13.0-alpha.0-63-g830fbac
 PKGS_PREFIX ?= ghcr.io/siderolabs
 TOOLS ?= v1.13.0-alpha.0-16-g9de9770
 TOOLS_PREFIX ?= ghcr.io/siderolabs

--- a/drivers/usb-modem/README.md
+++ b/drivers/usb-modem/README.md
@@ -25,6 +25,7 @@ machine:
       - name: ax88179_178a
       - name: cdc_ether
       - name: cdc_ncm
+      - name: ipheth
       - name: net1080
       - name: cdc_subset
       - name: zaurus

--- a/drivers/usb-modem/files/modules-aarch64.txt
+++ b/drivers/usb-modem/files/modules-aarch64.txt
@@ -24,6 +24,7 @@ kernel/drivers/net/usb/smsc95xx.ko
 kernel/drivers/net/usb/gl620a.ko
 kernel/drivers/net/usb/r8153_ecm.ko
 kernel/drivers/net/usb/cdc_ether.ko
+kernel/drivers/net/usb/ipheth.ko
 kernel/drivers/net/usb/cx82310_eth.ko
 kernel/drivers/net/usb/huawei_cdc_ncm.ko
 kernel/drivers/net/usb/kalmia.ko

--- a/drivers/usb-modem/files/modules-x86_64.txt
+++ b/drivers/usb-modem/files/modules-x86_64.txt
@@ -24,6 +24,7 @@ kernel/drivers/net/usb/smsc95xx.ko
 kernel/drivers/net/usb/gl620a.ko
 kernel/drivers/net/usb/r8153_ecm.ko
 kernel/drivers/net/usb/cdc_ether.ko
+kernel/drivers/net/usb/ipheth.ko
 kernel/drivers/net/usb/cx82310_eth.ko
 kernel/drivers/net/usb/huawei_cdc_ncm.ko
 kernel/drivers/net/usb/kalmia.ko


### PR DESCRIPTION
## Summary

- Add `ipheth.ko` (Apple iPhone USB Ethernet driver) to the `usb-modem-drivers` extension for both x86_64 and aarch64
- Update README to include `ipheth` in the module list
- Completes the USB network driver coverage in this extension

## Context

The `ipheth` module is an in-tree driver in `drivers/net/usb/` alongside the other USB network drivers already bundled in this extension. It provides iPhone USB Ethernet tethering support.

## Dependencies

Depends on siderolabs/pkgs#1473 to enable `CONFIG_USB_IPHETH=m` in the kernel config.