### PR TITLE
fix: iscsi-tools and multipath-tools

### DIFF
--- a/storage/iscsi-tools/iscsid.yaml
+++ b/storage/iscsi-tools/iscsid.yaml
@@ -16,11 +16,40 @@ container:
     readonlyPaths: []
     writeableSysfs: true
   mounts:
-    - source: /etc/iscsi/initiatorname.iscsi
-      destination: /etc/iscsi/initiatorname.iscsi
+    # ld-musl-x86_64.so.1
+    - source: /lib
+      destination: /lib
       type: bind
       options:
         - bind
+        - ro
+    # libcrypto.so and libc.so
+    - source: /usr/lib
+      destination: /usr/lib
+      type: bind
+      options:
+        - bind
+        - ro
+    # iscsi libs
+    - source: /usr/local/lib
+      destination: /usr/local/lib
+      type: bind
+      options:
+        - bind
+        - ro
+    - source: /usr/local/sbin
+      destination: /usr/local/sbin
+      type: bind
+      options:
+        - bind
+        - ro
+    # iscsi etc folder
+    - source: /etc/iscsi
+      destination: /etc/iscsi
+      type: bind
+      options:
+        - rshared
+        - rbind
         - ro
     - source: /var/lib/iscsi
       destination: /var/lib/iscsi

--- a/storage/iscsi-tools/pkg.yaml
+++ b/storage/iscsi-tools/pkg.yaml
@@ -3,21 +3,6 @@ variant: scratch
 shell: /bin/bash
 dependencies:
   - stage: base
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/fhs:{{ .BUILD_ARG_PKGS }}"
-    from: /
-    to: /rootfs/usr/local/lib/containers/iscsid
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/musl:{{ .BUILD_ARG_PKGS }}"
-    from: /usr/lib
-    to: /rootfs/usr/local/lib/containers/iscsid/usr/lib
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kmod:{{ .BUILD_ARG_PKGS }}"
-    from: /usr/lib
-    to: /rootfs/usr/local/lib/containers/iscsid/usr/lib
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/openssl:{{ .BUILD_ARG_PKGS }}"
-    from: /usr/lib
-    to: /rootfs/usr/local/lib/containers/iscsid/usr/lib
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/util-linux:{{ .BUILD_ARG_PKGS }}"
-    from: /usr/lib
-    to: /rootfs/usr/local/lib/containers/iscsid/usr/lib
 steps:
   - sources:
       - url: https://github.com/open-iscsi/open-iscsi/archive/refs/tags/{{ .OPEN_ISCSI_VERSION }}.tar.gz
@@ -45,8 +30,8 @@ steps:
           -Dno_systemd=true \
           -Disns=disabled \
           -Dhomedir=/etc/iscsi \
-          -Dprefix=/usr/local/lib/containers/iscsid \
-          -Discsi_sbindir=/usr/local/lib/containers/iscsid/usr/local/sbin \
+          -Dprefix=/usr/local \
+          -Discsi_sbindir=/usr/local/sbin \
           -Drulesdir=/usr/lib/udev/rules.d \
           output
 
@@ -58,9 +43,12 @@ steps:
 
         # cleanup
         # we generate initiatorname.iscsi on talos side.
-        rm -rf /rootfs/{etc,var}
+        rm -rf /rootfs/etc
+        rm -rf /rootfs/usr/local/{etc,share,include,pkgconfig}
+        rm -rf /rootfs/var
       - |
         mkdir -p /rootfs/usr/local/etc/containers
+        mkdir -p /rootfs/usr/local/lib/containers/iscsid
 
         cp /pkg/iscsid.yaml /rootfs/usr/local/etc/containers/
     test:

--- a/storage/multipath-tools/multipathd.yaml
+++ b/storage/multipath-tools/multipathd.yaml
@@ -4,11 +4,31 @@ container:
     maskedPaths: []
     readonlyPaths: []
     writeableRootfs: true
-  entrypoint: /sbin/multipathd
+  entrypoint: /usr/local/sbin/multipathd
   args:
     - -d
     - -s
   mounts:
+    # ld-musl-x86_64.so.1
+    - source: /lib
+      destination: /lib
+      type: bind
+      options:
+        - bind
+        - ro
+    # libs
+    - source: /usr/local/lib/
+      destination: /usr/local/lib/
+      type: bind
+      options:
+        - bind
+        - ro
+    - source: /usr/local/sbin
+      destination: /usr/local/sbin
+      type: bind
+      options:
+        - bind
+        - ro
     # /dev/mapper and multipath disk
     - source: /dev
       destination: /dev

--- a/storage/multipath-tools/pkg.yaml
+++ b/storage/multipath-tools/pkg.yaml
@@ -3,33 +3,6 @@ variant: scratch
 shell: /bin/bash
 dependencies:
   - stage: base
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/fhs:{{ .BUILD_ARG_PKGS }}"
-    from: /
-    to: /rootfs/usr/local/lib/containers/multipath-tools
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/musl:{{ .BUILD_ARG_PKGS }}"
-    from: /usr/lib
-    to: /rootfs/usr/local/lib/containers/multipath-tools/usr/lib
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/systemd-udevd:{{ .BUILD_ARG_PKGS }}"
-    from: /usr/lib
-    to: /rootfs/usr/local/lib/containers/multipath-tools/usr/lib
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/libjson-c:{{ .BUILD_ARG_PKGS }}"
-    from: /usr/lib
-    to: /rootfs/usr/local/lib/containers/multipath-tools/usr/lib
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/lvm2:{{ .BUILD_ARG_PKGS }}"
-    from: /usr/lib
-    to: /rootfs/usr/local/lib/containers/multipath-tools/usr/lib
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/liburcu:{{ .BUILD_ARG_PKGS }}"
-    from: /usr/lib
-    to: /rootfs/usr/local/lib/containers/multipath-tools/usr/lib
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/libaio:{{ .BUILD_ARG_PKGS }}"
-    from: /usr/lib
-    to: /rootfs/usr/local/lib/containers/multipath-tools/usr/lib
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/util-linux:{{ .BUILD_ARG_PKGS }}"
-    from: /usr/lib
-    to: /rootfs/usr/local/lib/containers/multipath-tools/usr/lib
-  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/libcap:{{ .BUILD_ARG_PKGS }}"
-    from: /usr/lib
-    to: /rootfs/usr/local/lib/containers/multipath-tools/usr/lib
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/systemd-udevd:{{ .BUILD_ARG_PKGS }}"
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/libjson-c:{{ .BUILD_ARG_PKGS }}"
   - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/lvm2:{{ .BUILD_ARG_PKGS }}"
@@ -48,10 +21,9 @@ steps:
         tar -xzf multipath-tools.tar.gz --strip-components=1
     build:
       - |
-        make -j $(nproc) prefix="/usr/local/lib/containers/multipath-tools" \
+        make -j $(nproc) prefix="/usr/local" \
           sysconfdir="/etc" \
           configdir="/etc/multipath/conf.d" \
-          plugindir="/usr/lib/multipath" \
           mandir="/usr/share/man" \
           infodir="/usr/share/info" \
           statedir="/etc/multipath" \
@@ -60,26 +32,25 @@ steps:
           SYSTEMD=""
     install:
       - |
-        mkdir -p /rootfs/usr/local/lib/containers/multipath-tools/usr/local/lib/
-
-        cp /usr/lib/libgcc_s.so.1 /rootfs/usr/local/lib/containers/multipath-tools/usr/local/lib/
-
-        make prefix="/usr/local/lib/containers/multipath-tools" DESTDIR=/rootfs LIB=lib install
+        mkdir -p /rootfs/usr/local/lib/containers/multipathd/ /rootfs/usr/local/lib/
+        cp /usr/lib/libgcc_s.so.1 /rootfs/usr/local/lib/
+        make prefix="/usr/local" DESTDIR=/rootfs LIB=lib install
       - |
         mkdir -p /rootfs/usr/local/etc/containers
-
         cp /pkg/multipathd.yaml /rootfs/usr/local/etc/containers/
       # Remove kernel module loading config
       - |
-        rm -rf /rootfs/usr/local/lib/containers/multipath-tools/modules-load.d
+        rm /rootfs/usr/lib/modules-load.d/multipath.conf
+        rmdir /rootfs/usr/lib/modules-load.d
       # Remove unnecessary docs and includes
       - |
-        rm -rf /rootfs/usr/local/lib/containers/multipath-tools/share
-        rm -rf /rootfs/usr/local/lib/containers/multipath-tools/include
+        rm -rf /rootfs/usr/local/share
+        rm -rf /rootfs/usr/local/include
       # This file tries to create a tmpfs mount at `/var/run/multipath`.
       - |
-        rm -rf /rootfs/usr/lib/tmpfiles.d/
-      # Removed but might be needed by other users of multipath-tools
+        rm /rootfs/usr/lib/tmpfiles.d/multipath.conf
+        rmdir /rootfs/usr/lib/tmpfiles.d
+      # # Removed but might be needed by other users of multipath-tools
       - |
         rm /rootfs/usr/lib/udev/kpartx_id
     test:


### PR DESCRIPTION
iscsi binaries needs to be present on the host.
Multipathd seems not to work when self-contained.

Fixes: https://github.com/siderolabs/talos/issues/12951
Fixes: https://github.com/siderolabs/extensions/issues/1006