### PR TITLE
fix: calculate correctly image digests for the catalog

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -123,8 +123,6 @@ spec:
       toplevel: true
     - name: check-dirty
       toplevel: true
-    - name: extensions-metadata
-      toplevel: true
     - name: internal/extensions/image-digests
       toplevel: true
     - name: internal/extensions/descriptions.yaml
@@ -185,7 +183,7 @@ spec:
     condition: on-pull-request
 ---
 kind: custom.Step
-name: extensions-metadata
+name: internal/extensions/image-digests
 spec:
   makefile:
     enabled: true
@@ -194,22 +192,9 @@ spec:
       - $(ARTIFACTS)/bldr
     script:
       - |
-        @rm -f _out/extensions-metadata
-        @$(foreach target,$(TARGETS),echo $(REGISTRY)/$(USERNAME)/$(target):$(shell $(ARTIFACTS)/bldr eval --target $(target) --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null) >> _out/extensions-metadata;)
-        @$(foreach target,$(NONFREE_TARGETS),echo $(REGISTRY)/$(USERNAME)/$(target):$(shell $(ARTIFACTS)/bldr eval --target $(target) --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null) >> _out/extensions-metadata;)
----
-kind: custom.Step
-name: internal/extensions/image-digests
-spec:
-  makefile:
-    enabled: true
-    phony: true
-    depends:
-      - extensions-metadata
-    script:
-      - |
-        @echo "Generating image digests..."
-        @cat _out/extensions-metadata | xargs -I{} sh -c 'echo {}@$$(crane digest {})' > internal/extensions/image-digests
+        @rm -f internal/extensions/image-digests
+        @$(foreach target,$(TARGETS),echo $(shell yq -r '."image.name" + "@" + ."containerimage.digest"' $(ARTIFACTS)/$(target).metadata.json) >> internal/extensions/image-digests;)
+        @$(foreach target,$(NONFREE_TARGETS),echo $(shell yq -r '."image.name" + "@" + ."containerimage.digest"' $(ARTIFACTS)/$(target).metadata.json) >> internal/extensions/image-digests;)
 ---
 kind: custom.Step
 name: internal/extensions/descriptions.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-03-17T11:01:23Z by kres 7bfd168.
+# Generated on 2026-03-17T13:52:47Z by kres 7bfd168-dirty.
 
 # common variables
 
@@ -238,7 +238,7 @@ nonfree: $(NONFREE_TARGETS)  ## Builds all nonfree targets defined.
 
 .PHONY: $(TARGETS) $(NONFREE_TARGETS)
 $(TARGETS) $(NONFREE_TARGETS): $(ARTIFACTS)/bldr
-	@$(MAKE) docker-$@ TARGET_ARGS="--tag=$(REGISTRY)/$(USERNAME)/$@:$(shell $(ARTIFACTS)/bldr eval --target $@ --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null) --push=$(PUSH)"
+	@$(MAKE) docker-$@ TARGET_ARGS="--tag=$(REGISTRY)/$(USERNAME)/$@:$(shell $(ARTIFACTS)/bldr eval --target $@ --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null) --push=$(PUSH) --metadata-file=$(ARTIFACTS)/$@.metadata.json"
 
 .PHONY: deps.svg
 deps.svg:  ## Generates a dependency graph of the Pkgfile.
@@ -258,16 +258,11 @@ extensions-catalog: $(ARTIFACTS)/bldr
 check-dirty:
 	@if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; git diff; exit 1 ; fi
 
-.PHONY: extensions-metadata
-extensions-metadata: $(ARTIFACTS)/bldr
-	@rm -f _out/extensions-metadata
-	@$(foreach target,$(TARGETS),echo $(REGISTRY)/$(USERNAME)/$(target):$(shell $(ARTIFACTS)/bldr eval --target $(target) --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null) >> _out/extensions-metadata;)
-	@$(foreach target,$(NONFREE_TARGETS),echo $(REGISTRY)/$(USERNAME)/$(target):$(shell $(ARTIFACTS)/bldr eval --target $(target) --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null) >> _out/extensions-metadata;)
-
 .PHONY: internal/extensions/image-digests
-internal/extensions/image-digests: extensions-metadata
-	@echo "Generating image digests..."
-	@cat _out/extensions-metadata | xargs -I{} sh -c 'echo {}@$$(crane digest {})' > internal/extensions/image-digests
+internal/extensions/image-digests: $(ARTIFACTS)/bldr
+	@rm -f internal/extensions/image-digests
+	@$(foreach target,$(TARGETS),echo $(shell yq -r '."image.name" + "@" + ."containerimage.digest"' $(ARTIFACTS)/$(target).metadata.json) >> internal/extensions/image-digests;)
+	@$(foreach target,$(NONFREE_TARGETS),echo $(shell yq -r '."image.name" + "@" + ."containerimage.digest"' $(ARTIFACTS)/$(target).metadata.json) >> internal/extensions/image-digests;)
 
 .PHONY: internal/extensions/descriptions.yaml
 internal/extensions/descriptions.yaml: internal/extensions/image-digests
@@ -314,4 +309,3 @@ release-notes: $(ARTIFACTS)
 conformance:
 	@docker pull $(CONFORMANCE_IMAGE)
 	@docker run --rm -it -v $(PWD):/src -w /src $(CONFORMANCE_IMAGE) enforce
-


### PR DESCRIPTION
Use buldkit's metadata file to find what went into the build instead of trying to resolve the digests on the fly.

Depends on kres change: https://github.com/siderolabs/kres/pull/627