### PR TITLE
fix: rework image digests one more time

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -123,6 +123,8 @@ spec:
       toplevel: true
     - name: check-dirty
       toplevel: true
+    - name: extensions-metadata
+      toplevel: true
     - name: internal/extensions/image-digests
       toplevel: true
     - name: internal/extensions/descriptions.yaml
@@ -183,6 +185,18 @@ spec:
     condition: on-pull-request
 ---
 kind: custom.Step
+name: extensions-metadata
+spec:
+  makefile:
+    enabled: true
+    phony: true
+    depends:
+      - internal/extensions/image-digests
+    script:
+      - |
+        @cp internal/extensions/image-digests $(ARTIFACTS)/extensions-metadata
+---
+kind: custom.Step
 name: internal/extensions/image-digests
 spec:
   makefile:
@@ -193,8 +207,8 @@ spec:
     script:
       - |
         @rm -f internal/extensions/image-digests
-        @$(foreach target,$(TARGETS),echo $(shell yq -r '."image.name" + "@" + ."containerimage.digest"' $(ARTIFACTS)/$(target).metadata.json) >> internal/extensions/image-digests;)
-        @$(foreach target,$(NONFREE_TARGETS),echo $(shell yq -r '."image.name" + "@" + ."containerimage.digest"' $(ARTIFACTS)/$(target).metadata.json) >> internal/extensions/image-digests;)
+        @$(foreach target,$(TARGETS),echo $(REGISTRY)/$(USERNAME)/$(target):$(shell $(ARTIFACTS)/bldr eval --target $(target) --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null)@$(shell yq -r '."containerimage.digest"' $(ARTIFACTS)/$(target).metadata.json) >> internal/extensions/image-digests;)
+        @$(foreach target,$(NONFREE_TARGETS),echo $(REGISTRY)/$(USERNAME)/$(target):$(shell $(ARTIFACTS)/bldr eval --target $(target) --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null)@$(shell yq -r '."containerimage.digest"' $(ARTIFACTS)/$(target).metadata.json) >> internal/extensions/image-digests;)
 ---
 kind: custom.Step
 name: internal/extensions/descriptions.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-03-17T13:52:47Z by kres 7bfd168-dirty.
+# Generated on 2026-03-17T18:42:59Z by kres 3675077.
 
 # common variables
 
@@ -258,11 +258,15 @@ extensions-catalog: $(ARTIFACTS)/bldr
 check-dirty:
 	@if test -n "`git status --porcelain`"; then echo "Source tree is dirty"; git status; git diff; exit 1 ; fi
 
+.PHONY: extensions-metadata
+extensions-metadata: internal/extensions/image-digests
+	@cp internal/extensions/image-digests $(ARTIFACTS)/extensions-metadata
+
 .PHONY: internal/extensions/image-digests
 internal/extensions/image-digests: $(ARTIFACTS)/bldr
 	@rm -f internal/extensions/image-digests
-	@$(foreach target,$(TARGETS),echo $(shell yq -r '."image.name" + "@" + ."containerimage.digest"' $(ARTIFACTS)/$(target).metadata.json) >> internal/extensions/image-digests;)
-	@$(foreach target,$(NONFREE_TARGETS),echo $(shell yq -r '."image.name" + "@" + ."containerimage.digest"' $(ARTIFACTS)/$(target).metadata.json) >> internal/extensions/image-digests;)
+	@$(foreach target,$(TARGETS),echo $(REGISTRY)/$(USERNAME)/$(target):$(shell $(ARTIFACTS)/bldr eval --target $(target) --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null)@$(shell yq -r '."containerimage.digest"' $(ARTIFACTS)/$(target).metadata.json) >> internal/extensions/image-digests;)
+	@$(foreach target,$(NONFREE_TARGETS),echo $(REGISTRY)/$(USERNAME)/$(target):$(shell $(ARTIFACTS)/bldr eval --target $(target) --build-arg TAG=$(TAG) '{{.VERSION}}' 2>/dev/null)@$(shell yq -r '."containerimage.digest"' $(ARTIFACTS)/$(target).metadata.json) >> internal/extensions/image-digests;)
 
 .PHONY: internal/extensions/descriptions.yaml
 internal/extensions/descriptions.yaml: internal/extensions/image-digests
@@ -309,3 +313,4 @@ release-notes: $(ARTIFACTS)
 conformance:
 	@docker pull $(CONFORMANCE_IMAGE)
 	@docker run --rm -it -v $(PWD):/src -w /src $(CONFORMANCE_IMAGE) enforce
+


### PR DESCRIPTION
For some reason buildx in the CI doesn't want to export full metadata, only the digest is exposed.

Use a mixed solution by building the image tag via bldr as previously, while attaching the digest from buildx.