### PR TITLE
fix: add /usr/bin symlinks for nvidia-ctk and nvidia-cdi-hook

### DIFF
--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-container-runtime/pkg.yaml
@@ -36,6 +36,10 @@ steps:
 
         find . -maxdepth 1 -type f -executable -exec cp {} /rootfs/usr/local/bin/ \;
       - |
+        mkdir -p /rootfs/usr/bin
+        ln -s /usr/local/bin/nvidia-ctk /rootfs/usr/bin/nvidia-ctk
+        ln -s /usr/local/bin/nvidia-cdi-hook /rootfs/usr/bin/nvidia-cdi-hook
+      - |
         mkdir -p /rootfs/etc/cri/conf.d
         cp /pkg/10-nvidia-container-runtime.part /rootfs/etc/cri/conf.d/10-nvidia-container-runtime.part
     sbom:


### PR DESCRIPTION
## What? (description)

Adds symlinks from `/usr/bin/nvidia-ctk` → `/usr/local/bin/nvidia-ctk` and `/usr/bin/nvidia-cdi-hook` → `/usr/local/bin/nvidia-cdi-hook` in the nvidia-container-toolkit extension build.

## Why? (reasoning)

The gpu-operator device plugin generates CDI specs with hooks pointing to `/usr/bin/nvidia-ctk` ([`DefaultNvidiaCTKPath`](https://github.com/NVIDIA/k8s-device-plugin/blob/main/api/config/v1/consts.go)) and `/usr/bin/nvidia-cdi-hook` ([`defaultNvidiaCDIHookPath`](https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/internal/discover/hooks.go)). Talos extensions install these binaries under `/usr/local/bin/`, so pods requesting `nvidia.com/gpu` resource limits fail with a "no such file" error.

This follows the exact pattern of the existing `/usr/bin/ldconfig` symlink. With these symlinks, the device plugin's default CDI hook paths resolve correctly and users no longer need to set `NVIDIA_CDI_HOOK_PATH` in their gpu-operator values.

**Depends on**: siderolabs/talos#13022 (validator allowlist update to permit `/usr/bin/nvidia-ctk` and `/usr/bin/nvidia-cdi-hook`)

Ref: siderolabs/talos#13021