### PR TITLE
fix: disable NVIDIA GPU check while building the driver

### DIFF
--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/lts/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/lts/pkg.yaml
@@ -75,6 +75,8 @@ steps:
           --no-wine-files \
           --no-kernel-module-source \
           --no-check-for-alternate-installs \
+          --no-nouveau-check \
+          --allow-installation-with-running-driver \
           --override-file-type-destination=OPENGL_DATA:/rootfs/usr/local/share/nvidia \
           --override-file-type-destination=VULKAN_ICD_JSON:/rootfs/etc/vulkan/icd.d \
           --override-file-type-destination=VULKANSC_ICD_JSON:/rootfs/etc/vulkansc/icd.d \

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/production/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/production/pkg.yaml
@@ -74,6 +74,8 @@ steps:
           --no-wine-files \
           --no-kernel-module-source \
           --no-check-for-alternate-installs \
+          --no-nouveau-check \
+          --allow-installation-with-running-driver \
           --override-file-type-destination=OPENGL_DATA:/rootfs/usr/local/share/nvidia \
           --override-file-type-destination=VULKAN_ICD_JSON:/rootfs/etc/vulkan/icd.d \
           --override-file-type-destination=VULKANSC_ICD_JSON:/rootfs/etc/vulkansc/icd.d \


### PR DESCRIPTION
E.g. my build machine has ancient NVIDIA GPU, and has noveau loaded, which aborts the build, but it doesn't make any sense as I'm not building it for my machine.