### PR TITLE
Export zpools on zfs shutdown

### DIFF
--- a/storage/zfs/zfs-service/main.go
+++ b/storage/zfs/zfs-service/main.go
@@ -31,4 +31,11 @@ func main() {
 	if err := cmd.Run(); err != nil {
 		log.Fatalf("zfs-service: zfs unmount error: %v\n", err)
 	}
+
+	cmd = exec.Command("/usr/local/sbin/zpool", "export", "-a")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("zfs-service: zpool export error: %v\n", err)
+	}
 }


### PR DESCRIPTION
Fixes cases where later tasks fail because the disks are still in use (e.g. closing encrypted volumes).

I ran into similar issues as https://github.com/siderolabs/talos/issues/9307 and https://github.com/siderolabs/talos/issues/8800 while setting up a new cluster with a ZFS data disk; since the pools are still active, `cryptsetup close` fails in a loop until it reaches the timeout and this also prevents the normal upgrade process from completing (`--stage` can still be used to upgrade but it takes much longer than necessary).