### PR TITLE
fix: enable for real joydev & uinput extensions

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -31,6 +31,7 @@ spec:
     - intel-npu
     - intel-ucode
     - iscsi-tools
+    - joydev
     - kata-containers
     - lldpd
     - mdadm
@@ -67,6 +68,7 @@ spec:
     - tenstorrent
     - thunderbolt
     - trident-iscsi-tools
+    - uhid
     - uinput
     - usb-modem-drivers
     - usb-audio-drivers

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-14T18:29:48Z by kres b6d29bf.
+# Generated on 2026-04-15T10:20:01Z by kres b6d29bf.
 
 # common variables
 
@@ -91,6 +91,7 @@ TARGETS += intel-ice-firmware
 TARGETS += intel-npu
 TARGETS += intel-ucode
 TARGETS += iscsi-tools
+TARGETS += joydev
 TARGETS += kata-containers
 TARGETS += lldpd
 TARGETS += mdadm
@@ -127,6 +128,7 @@ TARGETS += tailscale
 TARGETS += tenstorrent
 TARGETS += thunderbolt
 TARGETS += trident-iscsi-tools
+TARGETS += uhid
 TARGETS += uinput
 TARGETS += usb-modem-drivers
 TARGETS += usb-audio-drivers


### PR DESCRIPTION
This is a fix for PR #1038, without it the extensions are never built.