### PR TITLE
feat(bird2): allow bird to start in maintenance mode

### DIFF
--- a/network/bird2/bird2.yaml
+++ b/network/bird2/bird2.yaml
@@ -3,11 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 name: bird2
 depends:
-  - service: cri
-  - network:
-      - addresses
-      - etcfiles
-      - hostname
   - configuration: true
 container:
   entrypoint: /usr/local/sbin/bird


### PR DESCRIPTION
Closes #1064

### Problem

In a BGP-to-host topology bird is the component that brings the node's
address up: it peers with the ToR over IPv6 link-local (kernel
auto-assigned) and installs the routable address once the session is
established.

The current `network/bird2/bird2.yaml` depends block holds bird back
from the very things it fulfils:

| Dep                             | Why it deadlocks                                                             |
| ------------------------------- | ---------------------------------------------------------------------------- |
| `service: cri`                  | Only resolves after a machineconfig is applied. In maintenance mode it never resolves, so bird never starts. |
| `network: addresses`            | Circular: bird is what assigns the address.                                  |
| `network: etcfiles`             | Not needed for link-local peering (no DNS/hosts).                            |
| `network: hostname`             | Same - not needed for LL peering.                                            |

Net result with the upstream depends block: even with the boot-asset
embedded ESC and extension, bird sits Waiting forever and the node
never gets an address.

### Change

Drop all four. Leaves only `configuration: true`, so bird starts as
soon as its ExtensionServiceConfig is present.

### Compatibility

This is a behavioural change for existing users: bird now starts before
`cri` and before any address is assigned. For setups where bird is
purely an overlay/route announcer running on an already-bootstrapped
node, bird will start earlier and retry until peers are reachable.

### Validation

Forked the extension with this exact change, kept the binary and build
identical (BIRD 2.18, statically linked, prefix `/usr/local`). On a
bare-metal Talos 1.12 node with the extension and an ESC embedded into
the boot asset:

- bird starts in maintenance mode.
- BGP unnumbered comes up against the ToR.
- Node learns its routable address.
- Full machineconfig apply / bootstrap completes.

With the original depends block bird stayed Waiting indefinitely.

### Notes

Discussion in #1064 
@frezbo 