### PR TITLE
fix: nvme-cli install path

### DIFF
--- a/tools/nvme-cli/pkg.yaml
+++ b/tools/nvme-cli/pkg.yaml
@@ -24,6 +24,7 @@ steps:
         meson setup \
           -Db_lto=true \
           -Dudevrulesdir=/usr/lib/udev/rules.d \
+          -Dsbindir=/usr/bin \
           -Djson-c=enabled \
           -Ddocs=false \
           -Dsysconfdir=/etc \
@@ -37,8 +38,6 @@ steps:
 
         DESTDIR=/rootfs meson install -C .build
         rm -rf /rootfs/{etc/nvme/discovery.conf,usr/local/{include,lib/{dracut,systemd},share}}
-
-        ln -s /usr/local/sbin/nvme /rootfs/usr/bin/nvme
     test:
       - |
         mkdir -p /extensions-validator-rootfs


### PR DESCRIPTION
PR #1033 added allowlist of `/usr/bin/nvme` and #1034 started creating a symlink from `/usr/bin/nvme -> /usr/local/bin/nvme`, this meant containers mounting up `/` saw nvme symlinked to absolue `/usr/local/bin`which they cannot resolve, fix by putting the actual file as `/usr/bin/nvme`.