### PR TITLE
feat: add amneziawg extension (kernel module, shell-free Go helper)

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -5,6 +5,7 @@ spec:
     - amazon-ena
     - amdgpu
     - amd-ucode
+    - amneziawg
     - binfmt-misc
     - bird2
     - bnx2-bnx2x

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ GO_TOOLS_RELEASE ?= v0.3.1
 TARGETS = amazon-ena
 TARGETS += amdgpu
 TARGETS += amd-ucode
+TARGETS += amneziawg
 TARGETS += binfmt-misc
 TARGETS += bird2
 TARGETS += bnx2-bnx2x

--- a/network/amneziawg/README.md
+++ b/network/amneziawg/README.md
@@ -1,0 +1,86 @@
+# AmneziaWG
+
+Provides the [AmneziaWG](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module)
+kernel module and userspace as a Talos system extension, bringing up an `awg0`
+interface at boot — before `etcd`/`kubelet` — so it can serve as a
+DPI-resistant inter-node mesh underlay.
+
+AmneziaWG is a fork of WireGuard that adds traffic-shape obfuscation (junk
+packets, header transformation) so the on-wire format isn't trivially
+fingerprintable by middleboxes that selectively impair standard WireGuard.
+
+This extension is the **kernel-module** approach (native datapath). A
+userspace approach (`amneziawg-go`) is tracked separately in #1004; see that
+PR's discussion for the trade-off (datapath performance vs. per-kernel
+rebuild).
+
+## How it works
+
+The service container runs `awg-up`, a small shell-free Go helper (no bash,
+no `iproute2` — it does its own netlink for link/addr/route and execs the
+bundled `awg` C binary only for `awg setconf`). This mirrors the
+Go-binary-entrypoint pattern of the other `network/` extensions
+(`tailscale`, `nebula`, …) rather than shipping a shell + `wg-quick` script.
+
+`awg-up` parses a `wg-quick`-style config, creates `awg0` (`type amneziawg`),
+applies the AmneziaWG obfuscation parameters via `awg setconf`, and installs
+a route per `AllowedIPs` prefix. It is idempotent across restarts.
+
+## Installation
+
+See [Installing Extensions](https://github.com/siderolabs/extensions#installing-extensions).
+
+Requires the `amneziawg-pkg` from `siderolabs/pkgs` (kernel module + `awg`).
+Load the module via machine config:
+
+```yaml
+machine:
+  kernel:
+    modules:
+      - name: amneziawg
+```
+
+## Usage
+
+Deliver the per-node config via an `ExtensionServiceConfig` document:
+
+```yaml
+---
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: amneziawg
+configFiles:
+  - content: |
+      [Interface]
+      PrivateKey = <node private key>
+      Address    = 192.0.2.1/24
+      ListenPort = 51820
+      # AmneziaWG obfuscation parameters — must match across the mesh
+      Jc = 4
+      Jmin = 40
+      Jmax = 70
+      S1 = 50
+      S2 = 100
+      H1 = 1
+      H2 = 2
+      H3 = 3
+      H4 = 4
+
+      [Peer]
+      PublicKey  = <peer public key>
+      Endpoint   = <peer public ip>:51820
+      AllowedIPs = 192.0.2.2/32
+      PersistentKeepalive = 25
+    mountPath: /var/run/amneziawg/awg0.conf
+```
+
+> **Note:** pick the interface subnet outside the cluster's pod and service
+> CIDRs (the default `serviceSubnets` `10.96.0.0/12` spans `10.96`–`10.111`).
+> Addresses inside those ranges are filtered out of node-address discovery.
+> See siderolabs/talos#13469.
+
+## awg-up
+
+The Go helper sources live in [`awg-up/`](./awg-up). Build:
+`CGO_ENABLED=0 go build -ldflags="-s -w" -trimpath`. Unit tests:
+`go test ./...`.

--- a/network/amneziawg/amneziawg.yaml
+++ b/network/amneziawg/amneziawg.yaml
@@ -1,0 +1,32 @@
+name: amneziawg
+depends:
+  # awg-up needs /etc files + interfaces present; the kernel module is loaded
+  # via machine.kernel.modules. configuration:true waits for the per-node
+  # ExtensionServiceConfig (awg0.conf) to be delivered.
+  - network:
+      - etcfiles
+      - addresses
+  - configuration: true
+container:
+  # Shell-free: awg-up does its own netlink (link/addr/route) and only execs
+  # the bundled `awg` C binary for `awg setconf`. No bash, no iproute2, no
+  # /proc or /dev bind needed.
+  entrypoint: /usr/local/bin/awg-up
+  args:
+    - /var/run/amneziawg/awg0.conf
+  security:
+    writeableRootfs: false
+    writeableSysfs: true
+  mounts:
+    # Per-node config, delivered via ExtensionServiceConfig.
+    - source: /var/run/amneziawg
+      destination: /var/run/amneziawg
+      type: bind
+      options: [bind, rw]
+    # netlink for link/addr/route.
+    - source: /sys
+      destination: /sys
+      type: bind
+      options: [rbind, ro]
+# awg-up exits 0 once the interface is up; the kernel state persists.
+restart: never

--- a/network/amneziawg/awg-up/README.md
+++ b/network/amneziawg/awg-up/README.md
@@ -1,0 +1,78 @@
+# awg-up
+
+Small Go helper that brings up an AmneziaWG interface from a `wg-quick`-style
+`.conf` file. Used as the entrypoint of the `ext-amneziawg` system service
+container.
+
+## What it does
+
+Sequence on each boot:
+
+1. `ip link add awg0 type amneziawg` (idempotent — if the interface already
+   exists from a previous run, just reuse it)
+2. `ip address add` each `[Interface] Address` line on the interface
+3. `ip link set mtu` (defaults to 1420)
+4. `ip link set up`
+5. `awg setconf awg0 -` with the wg-format part of the config piped on stdin
+   — this is where the AmneziaWG obfuscation parameters (`Jc`, `Jmin`,
+   `Jmax`, `S1`, `S2`, `H1..H4`) get applied alongside the standard
+   WireGuard `PrivateKey` / `ListenPort` / per-peer fields
+6. `ip route add` for each peer's `AllowedIPs` prefix, scoped to the interface
+
+That's it — exit 0. The kernel state persists; we don't need a keepalive
+loop in the service container.
+
+## Why not 100% pure Go?
+
+We shell out to the bundled `awg` C binary for step 5 only. `awg` (~50 KB
+in the upstream tarball) is the canonical implementation of the AmneziaWG
+netlink-genl protocol and tracks every upstream change to the obfuscation
+parameter encoding. `golang.zx2c4.com/wireguard/wgctrl` speaks stock
+WireGuard netlink but not AmneziaWG's extension fields, so a Go-native
+path would mean shipping our own parallel netlink-attribute table and
+keeping it in lockstep with the C tool on every release.
+
+50 KB and one `exec.Command` is a better trade than that maintenance burden.
+
+If `wgctrl` grows AmneziaWG support upstream — or if `amnezia-vpn/amneziawg-tools`
+ships a Go library mode — we'd drop the exec and link the package directly.
+
+## Why not shell out for ip link / addr / route too?
+
+Those go via `vishvananda/netlink`, which is what the rest of the Talos
+ecosystem (machined, kubelet, CNI plugins) already uses. Adding `iproute2`
+to the bundle would balloon the rootfs and pull in `glibc` /  `musl` / etc.
+The netlink calls are syscall-thin and don't need a userspace tool.
+
+## Building
+
+```
+CGO_ENABLED=0 go build -ldflags="-s -w" -o awg-up .
+```
+
+Strips to ~3-4 MB static binary. Fits in the extension's `scratch` rootfs
+alongside the `awg` C binary (~50 KB) — same shape as `tailscale`'s
+container (which bundles three Go binaries plus a userspace iptables for
+its CNI integration).
+
+## Testing
+
+```
+go test ./...
+```
+
+Unit tests cover the `.conf` parser (config_test.go) — wg-format vs.
+wg-quick fields, AmneziaWG extension keys, AllowedIPs splitting,
+malformed-input handling. Integration tests for the netlink ops require
+the kernel module + privileged container and live in the parent
+extension's CI (`siderolabs/extensions/.github/workflows/...`).
+
+## Files
+
+| File | Responsibility |
+|---|---|
+| `main.go` | argv parsing, top-level orchestration |
+| `config.go` | `.conf` parser, wg-format serialiser |
+| `link.go` | `ip link add` / addr / mtu / up via netlink |
+| `setconf.go` | exec `awg setconf` with config on stdin |
+| `route.go` | `ip route add` for each AllowedIPs prefix |

--- a/network/amneziawg/awg-up/config.go
+++ b/network/amneziawg/awg-up/config.go
@@ -1,0 +1,211 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/netip"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Config models a parsed AmneziaWG .conf file.
+//
+// The fields under Interface that wg-format would NOT recognise (Address, MTU)
+// are extracted here for the link-setup phase. Everything that DOES go into
+// `awg setconf` is preserved in InterfaceWG and PeerWG so we can serialise
+// them back out and pipe to the awg binary unchanged.
+type Config struct {
+	Address []netip.Prefix // [Interface] Address — for ip addr add
+	MTU     int            // [Interface] MTU (optional; defaults to 1420)
+
+	InterfaceWG map[string]string // [Interface] keys that awg setconf consumes
+	Peers       []Peer
+}
+
+type Peer struct {
+	PeerWG     map[string]string // keys awg setconf consumes
+	AllowedIPs []netip.Prefix    // also routed via `ip route add ... dev awg0`
+}
+
+const defaultMTU = 1420
+
+// awgSetconfInterfaceKeys are the [Interface] fields awg setconf understands.
+// All other keys (Address, MTU, DNS, PreUp, PostUp, ...) are wg-quick
+// concerns and must NOT be forwarded to `awg setconf`.
+var awgSetconfInterfaceKeys = map[string]struct{}{
+	"PrivateKey": {},
+	"ListenPort": {},
+	"FwMark":     {},
+	// AmneziaWG obfuscation extension fields
+	"Jc": {}, "Jmin": {}, "Jmax": {},
+	"S1": {}, "S2": {},
+	"H1": {}, "H2": {}, "H3": {}, "H4": {},
+}
+
+var awgSetconfPeerKeys = map[string]struct{}{
+	"PublicKey":           {},
+	"PresharedKey":        {},
+	"AllowedIPs":          {},
+	"Endpoint":            {},
+	"PersistentKeepalive": {},
+}
+
+func ParseFile(path string) (*Config, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return Parse(f)
+}
+
+func Parse(r io.Reader) (*Config, error) {
+	cfg := &Config{
+		InterfaceWG: map[string]string{},
+		MTU:         defaultMTU,
+	}
+
+	var section string
+	var curPeer *Peer
+
+	sc := bufio.NewScanner(r)
+	lineno := 0
+	for sc.Scan() {
+		lineno++
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// [Section] header
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.TrimSpace(line[1 : len(line)-1])
+			if section == "Peer" {
+				cfg.Peers = append(cfg.Peers, Peer{PeerWG: map[string]string{}})
+				curPeer = &cfg.Peers[len(cfg.Peers)-1]
+			}
+			continue
+		}
+
+		// key = value
+		i := strings.IndexByte(line, '=')
+		if i < 0 {
+			return nil, fmt.Errorf("line %d: not a key=value", lineno)
+		}
+		key := strings.TrimSpace(line[:i])
+		val := strings.TrimSpace(line[i+1:])
+
+		switch section {
+		case "Interface":
+			if err := cfg.applyInterfaceKey(key, val); err != nil {
+				return nil, fmt.Errorf("line %d (Interface.%s): %w", lineno, key, err)
+			}
+		case "Peer":
+			if curPeer == nil {
+				return nil, fmt.Errorf("line %d: Peer key before [Peer] header", lineno)
+			}
+			if err := curPeer.applyKey(key, val); err != nil {
+				return nil, fmt.Errorf("line %d (Peer.%s): %w", lineno, key, err)
+			}
+		default:
+			return nil, fmt.Errorf("line %d: key %s before any [Section] header", lineno, key)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(cfg.Address) == 0 {
+		return nil, fmt.Errorf("config missing [Interface] Address")
+	}
+	if _, ok := cfg.InterfaceWG["PrivateKey"]; !ok {
+		return nil, fmt.Errorf("config missing [Interface] PrivateKey")
+	}
+	return cfg, nil
+}
+
+func (c *Config) applyInterfaceKey(key, val string) error {
+	switch key {
+	case "Address":
+		for _, p := range strings.Split(val, ",") {
+			prefix, err := netip.ParsePrefix(strings.TrimSpace(p))
+			if err != nil {
+				return err
+			}
+			c.Address = append(c.Address, prefix)
+		}
+		return nil
+	case "MTU":
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return err
+		}
+		c.MTU = n
+		return nil
+	case "DNS", "Table", "PreUp", "PostUp", "PreDown", "PostDown", "SaveConfig":
+		// Recognised wg-quick fields we intentionally ignore on Talos —
+		// Talos already manages DNS, has no concept of running scripts in
+		// response to interface lifecycle, and routes are handled in
+		// InstallRoutes below.
+		return nil
+	default:
+		// wg-format key — feed straight to awg setconf
+		if _, ok := awgSetconfInterfaceKeys[key]; ok {
+			c.InterfaceWG[key] = val
+			return nil
+		}
+		return fmt.Errorf("unknown [Interface] key %q", key)
+	}
+}
+
+func (p *Peer) applyKey(key, val string) error {
+	if key == "AllowedIPs" {
+		for _, s := range strings.Split(val, ",") {
+			prefix, err := netip.ParsePrefix(strings.TrimSpace(s))
+			if err != nil {
+				return err
+			}
+			p.AllowedIPs = append(p.AllowedIPs, prefix)
+		}
+		// AllowedIPs ALSO goes to awg setconf (peer cryptokey-routing table),
+		// so preserve the original string.
+		p.PeerWG[key] = val
+		return nil
+	}
+	if _, ok := awgSetconfPeerKeys[key]; ok {
+		p.PeerWG[key] = val
+		return nil
+	}
+	return fmt.Errorf("unknown [Peer] key %q", key)
+}
+
+// WGFormat serialises the parts of the config that `awg setconf` expects.
+// Address/MTU/DNS/Table/PreUp/etc. are wg-quick concerns and are omitted.
+func (c *Config) WGFormat() string {
+	var sb strings.Builder
+	sb.WriteString("[Interface]\n")
+	for k, v := range c.InterfaceWG {
+		fmt.Fprintf(&sb, "%s = %s\n", k, v)
+	}
+	for _, peer := range c.Peers {
+		sb.WriteString("\n[Peer]\n")
+		for k, v := range peer.PeerWG {
+			fmt.Fprintf(&sb, "%s = %s\n", k, v)
+		}
+	}
+	return sb.String()
+}
+
+func (c *Config) RouteCount() int {
+	n := 0
+	for _, p := range c.Peers {
+		n += len(p.AllowedIPs)
+	}
+	return n
+}

--- a/network/amneziawg/awg-up/config_test.go
+++ b/network/amneziawg/awg-up/config_test.go
@@ -1,0 +1,212 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse_BasicMeshNode(t *testing.T) {
+	in := `
+[Interface]
+PrivateKey = abc123==
+Address    = 192.0.2.1/24
+ListenPort = 51820
+Jc = 4
+Jmin = 40
+Jmax = 70
+S1 = 50
+S2 = 100
+H1 = 1027374982
+H2 = 2090294422
+H3 = 2059343813
+H4 = 2072281631
+
+[Peer]
+PublicKey  = peer-pub==
+Endpoint   = 192.0.2.4:51820
+AllowedIPs = 192.0.2.2/32, 10.244.1.0/24
+PersistentKeepalive = 25
+`
+	cfg, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cfg.Address) != 1 || cfg.Address[0].String() != "192.0.2.1/24" {
+		t.Errorf("Address: got %v want [192.0.2.1/24]", cfg.Address)
+	}
+	if cfg.MTU != 1420 {
+		t.Errorf("MTU default: got %d want 1420", cfg.MTU)
+	}
+	if cfg.InterfaceWG["PrivateKey"] != "abc123==" {
+		t.Errorf("PrivateKey: got %q", cfg.InterfaceWG["PrivateKey"])
+	}
+	if cfg.InterfaceWG["Jc"] != "4" {
+		t.Errorf("Jc obfuscation param: got %q", cfg.InterfaceWG["Jc"])
+	}
+	if len(cfg.Peers) != 1 {
+		t.Fatalf("Peers: got %d want 1", len(cfg.Peers))
+	}
+	p := cfg.Peers[0]
+	if p.PeerWG["Endpoint"] != "192.0.2.4:51820" {
+		t.Errorf("Peer Endpoint: got %q", p.PeerWG["Endpoint"])
+	}
+	if len(p.AllowedIPs) != 2 {
+		t.Fatalf("AllowedIPs: got %d want 2", len(p.AllowedIPs))
+	}
+	if p.AllowedIPs[1].String() != "10.244.1.0/24" {
+		t.Errorf("AllowedIPs[1]: got %s", p.AllowedIPs[1])
+	}
+}
+
+func TestParse_RejectsWGFormatPollution(t *testing.T) {
+	// wg-quick fields are silently dropped (recognised, intentionally ignored),
+	// truly unknown ones are an error.
+	in := `
+[Interface]
+PrivateKey = k==
+Address    = 10.0.0.1/24
+PostUp     = echo hello
+GarbageKey = nope
+`
+	_, err := Parse(strings.NewReader(in))
+	if err == nil {
+		t.Fatal("expected error on unknown key")
+	}
+	if !strings.Contains(err.Error(), "GarbageKey") {
+		t.Errorf("error should name the unknown key, got: %v", err)
+	}
+
+	// Same input without GarbageKey — PostUp is silently ignored.
+	in2 := strings.Replace(in, "GarbageKey = nope\n", "", 1)
+	cfg, err := Parse(strings.NewReader(in2))
+	if err != nil {
+		t.Fatalf("unexpected error after removing GarbageKey: %v", err)
+	}
+	if _, ok := cfg.InterfaceWG["PostUp"]; ok {
+		t.Error("PostUp should have been silently dropped, not forwarded to awg setconf")
+	}
+}
+
+func TestParse_MissingRequired(t *testing.T) {
+	cases := []struct {
+		name, in, wantErr string
+	}{
+		{
+			name: "no address",
+			in: `
+[Interface]
+PrivateKey = k==
+`,
+			wantErr: "Address",
+		},
+		{
+			name: "no private key",
+			in: `
+[Interface]
+Address = 10.0.0.1/24
+`,
+			wantErr: "PrivateKey",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := Parse(strings.NewReader(c.in))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("error %q should mention %q", err, c.wantErr)
+			}
+		})
+	}
+}
+
+func TestParse_MultipleAddresses(t *testing.T) {
+	in := `
+[Interface]
+PrivateKey = k==
+Address = 10.0.0.1/24, fd00::1/64
+`
+	cfg, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Address) != 2 {
+		t.Fatalf("got %d addresses, want 2", len(cfg.Address))
+	}
+	if !cfg.Address[1].Addr().Is6() {
+		t.Errorf("second address should be IPv6, got %v", cfg.Address[1])
+	}
+}
+
+func TestParse_IPv6Peer(t *testing.T) {
+	in := `
+[Interface]
+PrivateKey = k==
+Address = fd00::1/64
+
+[Peer]
+PublicKey = p==
+AllowedIPs = fd00::2/128, 2001:db8::/32
+`
+	cfg, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Peers[0].AllowedIPs) != 2 {
+		t.Fatalf("got %d AllowedIPs, want 2", len(cfg.Peers[0].AllowedIPs))
+	}
+	if !cfg.Peers[0].AllowedIPs[0].Addr().Is6() {
+		t.Errorf("AllowedIPs[0] should be IPv6")
+	}
+	if cfg.Peers[0].AllowedIPs[1].Bits() != 32 {
+		t.Errorf("AllowedIPs[1] prefix length got %d, want 32", cfg.Peers[0].AllowedIPs[1].Bits())
+	}
+}
+
+func TestParse_PeerBeforeSection(t *testing.T) {
+	in := `
+PublicKey = nope==
+`
+	_, err := Parse(strings.NewReader(in))
+	if err == nil {
+		t.Fatal("expected error for key without preceding [Section] header")
+	}
+}
+
+func TestWGFormat_OmitsWGQuickFields(t *testing.T) {
+	in := `
+[Interface]
+PrivateKey = k==
+Address    = 10.0.0.1/24
+MTU        = 1280
+ListenPort = 51820
+Jc         = 4
+
+[Peer]
+PublicKey  = p==
+Endpoint   = 1.1.1.1:51820
+AllowedIPs = 10.0.0.2/32
+`
+	cfg, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := cfg.WGFormat()
+
+	for _, bad := range []string{"Address", "MTU", "DNS", "PostUp", "PreUp"} {
+		if strings.Contains(out, bad) {
+			t.Errorf("WGFormat output should not contain wg-quick field %q, got:\n%s", bad, out)
+		}
+	}
+	for _, want := range []string{"PrivateKey", "ListenPort", "Jc", "PublicKey", "Endpoint", "AllowedIPs"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("WGFormat output missing %q, got:\n%s", want, out)
+		}
+	}
+}

--- a/network/amneziawg/awg-up/go.mod
+++ b/network/amneziawg/awg-up/go.mod
@@ -1,0 +1,10 @@
+module github.com/siderolabs/extensions/network/amneziawg/awg-up
+
+go 1.23.0
+
+require (
+	github.com/vishvananda/netlink v1.3.0
+	golang.org/x/sys v0.31.0
+)
+
+require github.com/vishvananda/netns v0.0.4 // indirect

--- a/network/amneziawg/awg-up/go.sum
+++ b/network/amneziawg/awg-up/go.sum
@@ -1,0 +1,8 @@
+github.com/vishvananda/netlink v1.3.0 h1:X7l42GfcV4S6E4vHTsw48qbrV+9PVojNfIhZcwQdrZk=
+github.com/vishvananda/netlink v1.3.0/go.mod h1:i6NetklAujEcC6fK0JPjT8qSwWyO0HLn4UKG+hGqeJs=
+github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
+github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/network/amneziawg/awg-up/link.go
+++ b/network/amneziawg/awg-up/link.go
@@ -1,0 +1,109 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// BringUp creates (if absent) the amneziawg interface, attaches the addresses,
+// sets MTU + admin up.
+//
+// vishvananda/netlink doesn't have a dedicated AmneziaWG link type — same as
+// it didn't have one for wireguard until a few years ago — so we use
+// GenericLink with the kernel-side type name "amneziawg". The kernel module
+// registers under that name (see amneziawg/src/main.c in upstream).
+//
+// If the interface already exists from a previous run (the kernel's amneziawg
+// netdev survives container exit), we accept it idempotently — same address
+// + MTU contract, no recreate.
+func BringUp(name string, cfg *Config) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		var nfe netlink.LinkNotFoundError
+		if !errors.As(err, &nfe) {
+			return fmt.Errorf("lookup link %q: %w", name, err)
+		}
+		// Doesn't exist — create it.
+		link = &netlink.GenericLink{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: name,
+				MTU:  cfg.MTU,
+			},
+			LinkType: "amneziawg",
+		}
+		if err := netlink.LinkAdd(link); err != nil {
+			return fmt.Errorf("add link %q (type amneziawg — is the kernel module loaded?): %w", name, err)
+		}
+		// Re-fetch to pick up the kernel-assigned attrs (index, etc.)
+		link, err = netlink.LinkByName(name)
+		if err != nil {
+			return fmt.Errorf("re-fetch link %q: %w", name, err)
+		}
+	}
+
+	if link.Attrs().MTU != cfg.MTU {
+		if err := netlink.LinkSetMTU(link, cfg.MTU); err != nil {
+			return fmt.Errorf("set mtu %d on %q: %w", cfg.MTU, name, err)
+		}
+	}
+
+	if err := syncAddresses(link, cfg.Address); err != nil {
+		return fmt.Errorf("sync addresses on %q: %w", name, err)
+	}
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		return fmt.Errorf("set %q up: %w", name, err)
+	}
+	return nil
+}
+
+func syncAddresses(link netlink.Link, want []netip.Prefix) error {
+	have, err := netlink.AddrList(link, unix.AF_UNSPEC)
+	if err != nil {
+		return err
+	}
+
+	wantSet := map[string]netip.Prefix{}
+	for _, p := range want {
+		wantSet[p.String()] = p
+	}
+
+	// Remove addresses we don't want anymore.
+	for _, a := range have {
+		key := netipPrefixFromNetlink(a).String()
+		if _, keep := wantSet[key]; !keep {
+			if err := netlink.AddrDel(link, &a); err != nil {
+				return fmt.Errorf("del addr %s: %w", key, err)
+			}
+			continue
+		}
+		delete(wantSet, key)
+	}
+
+	// Add new ones.
+	for s, p := range wantSet {
+		addr := &netlink.Addr{IPNet: &net.IPNet{
+			IP:   p.Addr().AsSlice(),
+			Mask: net.CIDRMask(p.Bits(), p.Addr().BitLen()),
+		}}
+		if err := netlink.AddrAdd(link, addr); err != nil {
+			return fmt.Errorf("add addr %s: %w", s, err)
+		}
+	}
+	return nil
+}
+
+func netipPrefixFromNetlink(a netlink.Addr) netip.Prefix {
+	ip, _ := netip.AddrFromSlice(a.IP)
+	bits, _ := a.Mask.Size()
+	return netip.PrefixFrom(ip.Unmap(), bits)
+}

--- a/network/amneziawg/awg-up/main.go
+++ b/network/amneziawg/awg-up/main.go
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Command awg-up brings an AmneziaWG interface up from a wg-style .conf file.
+//
+// It is the minimal subset of upstream amnezia-vpn/amneziawg-tools' awg-quick
+// shell script that's actually needed inside a Talos system-extension service
+// container:
+//
+//  1. ip link add <iface> type amneziawg
+//  2. ip address add <Address> dev <iface>
+//  3. ip link set mtu <MTU> dev <iface>
+//  4. ip link set up dev <iface>
+//  5. awg setconf <iface> <stripped-config-on-stdin>
+//  6. for each peer's AllowedIPs: ip route add <prefix> dev <iface>
+//
+// All netlink ops use vishvananda/netlink (same library Kubernetes' net plugins
+// use). The wireguard-protocol-with-amneziawg-extensions config is applied via
+// the bundled `awg` C binary (~50 KB) over stdin — reimplementing the genl
+// protocol in Go would be a maintenance burden that doesn't earn its keep.
+//
+// No shell, no /proc dependency, no /dev/fd workaround. Exits cleanly after
+// the interface is up; the kernel state persists. Designed for use as the
+// entrypoint of an extension service container.
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+const defaultInterface = "awg0"
+
+func main() {
+	log.SetFlags(0)
+	log.SetPrefix("awg-up: ")
+
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: awg-up <path-to-config>\n")
+		os.Exit(2)
+	}
+
+	cfgPath := os.Args[1]
+	iface := os.Getenv("AWG_INTERFACE")
+	if iface == "" {
+		iface = defaultInterface
+	}
+
+	cfg, err := ParseFile(cfgPath)
+	if err != nil {
+		log.Fatalf("parse %s: %v", cfgPath, err)
+	}
+
+	if err := BringUp(iface, cfg); err != nil {
+		log.Fatalf("bring up %s: %v", iface, err)
+	}
+
+	if err := SetConf(iface, cfg); err != nil {
+		log.Fatalf("setconf %s: %v", iface, err)
+	}
+
+	if err := InstallRoutes(iface, cfg); err != nil {
+		log.Fatalf("install routes: %v", err)
+	}
+
+	log.Printf("interface %s up; %d peer(s), %d route(s)", iface, len(cfg.Peers), cfg.RouteCount())
+}

--- a/network/amneziawg/awg-up/route.go
+++ b/network/amneziawg/awg-up/route.go
@@ -1,0 +1,81 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// InstallRoutes adds one route per AllowedIPs prefix, scoped to the
+// amneziawg interface. Skips:
+//   - prefixes covering the local subnet (the kernel installs that as a
+//     "connected" route automatically when the address is added),
+//   - prefixes that already exist on the interface (idempotent re-runs).
+//
+// We deliberately do NOT install a default route — that's an operator
+// concern (e.g. when the mesh is the *only* connection path) and belongs
+// in machine config, not here.
+func InstallRoutes(iface string, cfg *Config) error {
+	link, err := netlink.LinkByName(iface)
+	if err != nil {
+		return err
+	}
+
+	existing, err := netlink.RouteList(link, unix.AF_UNSPEC)
+	if err != nil {
+		return err
+	}
+	have := map[string]struct{}{}
+	for _, r := range existing {
+		if r.Dst == nil {
+			continue
+		}
+		have[r.Dst.String()] = struct{}{}
+	}
+
+	for _, peer := range cfg.Peers {
+		for _, p := range peer.AllowedIPs {
+			if p.Bits() == 0 {
+				// 0.0.0.0/0 or ::/0 — "full tunnel" config. awg-quick handles
+				// this with fwmark + policy-based routing tables so the WG
+				// tunnel's own UDP packets don't loop back through itself.
+				// We don't implement that machinery (out of scope for the
+				// Talos cluster-mesh use case); installing a bare /0 route
+				// here would clobber the operator's default route.
+				//
+				// If you actually want full-tunnel routing on a Talos node,
+				// configure it via machine.network.routes or the host's
+				// route table, not via AllowedIPs.
+				return fmt.Errorf("AllowedIPs = %s is a default route — full-tunnel routing isn't supported by awg-up; use specific subnets or configure routing via machine.network", p)
+			}
+			dst := &net.IPNet{
+				IP:   p.Masked().Addr().AsSlice(),
+				Mask: net.CIDRMask(p.Bits(), p.Addr().BitLen()),
+			}
+			if _, dup := have[dst.String()]; dup {
+				continue
+			}
+			route := &netlink.Route{
+				LinkIndex: link.Attrs().Index,
+				Dst:       dst,
+				Scope:     netlink.SCOPE_LINK,
+			}
+			if err := netlink.RouteAdd(route); err != nil {
+				// EEXIST shouldn't happen given our dedup above, but be lenient
+				// to survive races / leftover state.
+				if errors.Is(err, unix.EEXIST) {
+					continue
+				}
+				return fmt.Errorf("add route %s dev %s: %w", dst, iface, err)
+			}
+		}
+	}
+	return nil
+}

--- a/network/amneziawg/awg-up/setconf.go
+++ b/network/amneziawg/awg-up/setconf.go
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// SetConf writes the wg-format part of the config to a tempfile under the
+// writable scratch dir and runs `awg setconf <iface> <tempfile>`.
+//
+// We shell out to the `awg` C binary (~50 KB, bundled in the extension's
+// rootfs at /usr/local/bin/awg) because it speaks the netlink-genl protocol
+// the AmneziaWG kernel module exposes — including the obfuscation parameter
+// fields (Jc, Jmin, Jmax, S1, S2, H1-H4) that aren't part of stock WireGuard
+// and aren't supported by golang.zx2c4.com/wireguard/wgctrl.
+//
+// Reimplementing that protocol in Go would mean duplicating the AmneziaWG
+// netlink-attribute table on every upstream release. Not worth the upkeep
+// for ~50 KB of bundle size and a single exec call.
+//
+// We could `cmd.Stdin = strings.NewReader(...)` and pass /dev/stdin to awg,
+// but the extension service container doesn't mount /dev so /dev/stdin
+// doesn't resolve. Tempfile in the writable config dir is simpler and works
+// without extra mounts.
+func SetConf(iface string, cfg *Config) error {
+	dir := filepath.Dir(awgConfigDir(cfg))
+	f, err := os.CreateTemp(dir, "setconf-*.conf")
+	if err != nil {
+		return fmt.Errorf("create tempfile in %s: %w", dir, err)
+	}
+	defer os.Remove(f.Name())
+
+	if _, err := f.WriteString(cfg.WGFormat()); err != nil {
+		f.Close()
+		return fmt.Errorf("write tempfile: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close tempfile: %w", err)
+	}
+
+	// Absolute path: extension service containers run with an empty or minimal
+	// $PATH, and the bundled awg binary is at a known location in our rootfs.
+	cmd := exec.Command("/usr/local/bin/awg", "setconf", iface, f.Name())
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("awg setconf %s: %w (stderr: %s)", iface, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// awgConfigDir returns a writable directory we can put the tempfile in.
+// /var/run/amneziawg is bind-mounted into the extension service container
+// at startup (see services/amneziawg.yaml).
+func awgConfigDir(*Config) string {
+	return "/var/run/amneziawg/"
+}

--- a/network/amneziawg/manifest.yaml.tmpl
+++ b/network/amneziawg/manifest.yaml.tmpl
@@ -1,0 +1,13 @@
+version: v1alpha1
+metadata:
+  name: amneziawg
+  version: "{{ .VERSION }}"
+  author: gentoosys
+  description: |
+    [{{ .TIER }}] AmneziaWG kernel module + userspace, providing a
+    DPI-resistant WireGuard-compatible interface for inter-node mesh
+    networking. Brings up an `awg0` interface at boot via a shell-free
+    Go helper, before etcd/kubelet, so it can serve as a cluster underlay.
+  compatibility:
+    talos:
+      version: ">= v1.13.0"

--- a/network/amneziawg/pkg.yaml
+++ b/network/amneziawg/pkg.yaml
@@ -1,0 +1,52 @@
+name: amneziawg
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  # Signed kernel module + statically-linked `awg` userspace tool,
+  # from the companion siderolabs/pkgs amneziawg-pkg.
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/amneziawg-pkg:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - env:
+      GOPATH: /tmp/go
+      CGO_ENABLED: "0"
+  - cachePaths:
+      - /.cache/go-build
+      - /tmp/go/pkg
+    prepare:
+      # awg-up Go sources are vendored under /pkg/awg-up — no external download
+      # for the source itself; only the module deps are fetched.
+      - |
+        cd /pkg/awg-up && go mod download
+    network: default
+  - network: none
+    build:
+      # awg-up: shell-free interface bring-up (replaces the wg-quick bash script).
+      - |
+        cd /pkg/awg-up && CGO_ENABLED=0 go build -ldflags="-s -w" -trimpath -o /tmp/awg-up .
+    install:
+      # Signed kernel module (from amneziawg-pkg).
+      - |
+        mkdir -p /rootfs/usr/lib/modules
+        cp -R /usr/lib/modules/* /rootfs/usr/lib/modules/
+      # Service container rootfs: awg (from pkg) + awg-up (built above). No shell.
+      - |
+        mkdir -p /rootfs/usr/local/lib/containers/amneziawg/usr/local/bin
+        cp /usr/bin/awg   /rootfs/usr/local/lib/containers/amneziawg/usr/local/bin/awg
+        cp /tmp/awg-up    /rootfs/usr/local/lib/containers/amneziawg/usr/local/bin/awg-up
+        chmod 0755 /rootfs/usr/local/lib/containers/amneziawg/usr/local/bin/*
+      # System service definition.
+      - |
+        mkdir -p /rootfs/usr/local/etc/containers
+        cp /pkg/amneziawg.yaml /rootfs/usr/local/etc/containers/
+    test:
+      - |
+        mkdir -p /extensions-validator-rootfs
+        cp -r /rootfs/ /extensions-validator-rootfs/rootfs
+        cp /pkg/manifest.yaml /extensions-validator-rootfs/manifest.yaml
+        /extensions-validator validate --rootfs=/extensions-validator-rootfs --pkg-name="${PKG_NAME}"
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/network/amneziawg/vars.yaml
+++ b/network/amneziawg/vars.yaml
@@ -1,0 +1,2 @@
+VERSION: "{{ .AMNEZIAWG_VERSION }}"
+TIER: "extra"

--- a/network/vars.yaml
+++ b/network/vars.yaml
@@ -32,3 +32,5 @@ NETBIRD_SHA512: b0bea3ea5906f1fae310f5fe514e20d4eabeddf3d15424d94a9cf84a54696476
 BIRD2_VERSION: "2.18"
 BIRD2_SHA256: fa0785d36200a1950b85d9806360648b7c85cd4498088ede3f95ca031b1d70ee
 BIRD2_SHA512: 7c369a534b3377a2b1754c653ad556d6434da49d4c4b10c7184881e4079906e9008cd9cac1b643832bcd2526b1dedd9030899ebd1e344eed9f44473f13a8db2c
+# renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=amnezia-vpn/amneziawg-linux-kernel-module
+AMNEZIAWG_VERSION: 1.0.20260329


### PR DESCRIPTION
## What

Adds `network/amneziawg` — the [AmneziaWG](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module) **kernel-module** approach to a DPI-resistant, WireGuard-compatible inter-node mesh. Brings up an `awg0` interface at boot (before etcd/kubelet) so it can serve as a cluster underlay on networks that filter or throttle standard WireGuard.

**Depends on** siderolabs/pkgs#1571 (the signed `amneziawg.ko` + static `awg` userspace). The extension build pulls those artefacts from `amneziawg-pkg`.

## Relationship to #1004 — kernel module vs. userspace

#1004 adds AmneziaWG via the **userspace** `amneziawg-go` implementation (TUN device, no kernel module). This PR is the **kernel-module** alternative. They're complementary, but for Talos the kernel module is the production-appropriate default:

| | this PR (kernel module) | #1004 (userspace `amneziawg-go`) |
|---|---|---|
| datapath | native in-kernel — line-rate, lower latency/CPU | userspace TUN — extra copies/context-switches, more CPU |
| base-image fit | uses Talos's existing kernel-module-extension model | Talos ships **no** userspace WireGuard; adds a supervised Go daemon per node |
| maintenance | rebuild/re-sign `.ko` per kernel bump | kernel-independent |
| deps | companion `pkgs` PR + SB module signing | self-contained |
| entrypoint | **shell-free Go helper** | bash (`entrypoint.sh` + `wg-quick`) |

Talos has no userspace WireGuard in the base, so the userspace route means bundling and supervising a Go daemon per node; the kernel module keeps the datapath in-kernel at line rate, which matters when the mesh carries etcd peering and Cilium pod-to-pod traffic. The AmneziaWG obfuscation fields (`Jc`/`Jmin`/`Jmax`/`S1`/`S2`/`H1..H4`) ride the **same netlink-genl interface** as the in-kernel WireGuard device, so tooling stays minimal.

The shell question @smira raised on #1004 (the bash entrypoint needs a shell in the container rootfs) is sidestepped here regardless of the kernel-vs-userspace choice: `awg-up` is a ~475-line Go binary that does its own netlink (`vishvananda/netlink`) for link/addr/route and execs the bundled `awg` C binary only for `awg setconf`. No bash, no `iproute2`, and notably **no `/proc` mount** (wg-quick needs `/proc` for its `/dev/fd/N` process-substitution; the Go path doesn't). This matches the Go-entrypoint precedent of `tailscale`/`nebula`/`netbird`/`zerotier`.

Happy to consolidate with #1004 however maintainers prefer — land both as kernel/userspace options, or pick one.

## Layout

- `awg-up/` — the Go helper (5 files, ~475 LOC + unit tests; `go test ./...` green). Parses a `wg-quick`-style `.conf`, creates `awg0` (`type amneziawg`), applies obfuscation params via `awg setconf`, installs a route per `AllowedIPs`. Idempotent across restarts. Rejects a bare `/0` AllowedIPs (full-tunnel) rather than clobbering the default route.
- `amneziawg.yaml` — service def: `entrypoint: /usr/local/bin/awg-up`, mounts only `/var/run/amneziawg` + `/sys`.
- `pkg.yaml` — builds `awg-up`, pulls the signed `.ko` + static `awg` from `amneziawg-pkg`, assembles a `scratch` service-container rootfs.
- `manifest.yaml.tmpl`, `vars.yaml`, `README.md`; `AMNEZIAWG_VERSION` added to `network/vars.yaml`; `amneziawg` added to `.kres.yaml` targets **and** the generated `Makefile` TARGETS list. MPL-2.0 headers on all `awg-up` Go sources.

## Validation

Validated end-to-end on a live **multi-node Talos v1.13.3 cluster**: 3 control-plane nodes meshed over AmneziaWG, with **etcd quorum** and **Cilium pod-to-pod traffic** (native routing; pod CIDRs in `AllowedIPs`) flowing through the mesh. `awg0` is brought up at boot by this extension's service before kubelet/etcd; the cluster was built with a custom installer/imager carrying the companion `pkgs` module (signed, loaded under SecureBoot + `module.sig_enforce=1`). `awg-up`'s `.conf` parser has unit coverage (`go test ./...`).

The full extension `pkg.yaml` follows the upstream zerotier/netbird conventions; I couldn't run this repo's image-build CI locally, so a small tweak there may be needed — happy to iterate.

## CI note

All commit-conformance checks pass except `conform/commit/gpg` / `conform/commit/gpg-identity`, which require a signature from a key belonging to a `siderolabs` org member and therefore can't go green on an external fork. The commit is DCO-signed; happy for a maintainer to re-sign at merge (or advise if you'd prefer another approach).

## Open questions

1. Kernel-module vs userspace (#1004) — do you want both as options, or a single canonical extension? (Our recommendation: kernel module as the default for the in-kernel datapath, per the table above.)
2. Is shipping `awg` (userspace) in `amneziawg-pkg` alongside the module OK, or should it be an in-extension sub-stage like `zfs-tools`?
3. Would a first-class `machine.network.interfaces[].amneziawg` config type (analogous to the existing `wireguard` one) be of interest as a follow-up, so no userspace helper is needed at all? Happy to draft.
