### PR TITLE
fix: bound zpool export at shutdown with a configurable timeout

### DIFF
--- a/storage/zfs/zfs-service/main.go
+++ b/storage/zfs/zfs-service/main.go
@@ -5,13 +5,23 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 	"os/exec"
 	"os/signal"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
+
+// defaultExportTimeout bounds the shutdown `zpool export -a` so this PID 1 exits
+// before Talos's fixed 10s SIGTERM->SIGKILL grace for extension services,
+// leaving headroom for `zfs unmount -au`, the 1s WaitDelay, and a clean process
+// exit so the containerd shim can unmount the /dev rbind in order. Override with
+// the ZFS_EXPORT_TIMEOUT env var (a Go duration); 0 skips the export entirely
+// (pre-v1.13.0 behavior, before #1028 added the export).
+const defaultExportTimeout = 8 * time.Second
 
 func main() {
 	cmd := exec.Command("/usr/local/sbin/zpool", "import", "-fal")
@@ -32,10 +42,35 @@ func main() {
 		log.Fatalf("zfs-service: zfs unmount error: %v\n", err)
 	}
 
-	cmd = exec.Command("/usr/local/sbin/zpool", "export", "-a")
+	// ZFS_EXPORT_TIMEOUT overrides the bound; 0 skips the export entirely.
+	timeout := defaultExportTimeout
+	if v := os.Getenv("ZFS_EXPORT_TIMEOUT"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			log.Printf("zfs-service: invalid ZFS_EXPORT_TIMEOUT %q: %v; using %s\n", v, err, timeout)
+		} else {
+			timeout = d
+		}
+	}
+
+	if timeout == 0 {
+		log.Printf("zfs-service: ZFS_EXPORT_TIMEOUT=0, skipping zpool export; pools will be re-imported on next boot\n")
+
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd = exec.CommandContext(ctx, "/usr/local/sbin/zpool", "export", "-a")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.WaitDelay = time.Second
+
 	if err := cmd.Run(); err != nil {
-		log.Fatalf("zfs-service: zpool export error: %v\n", err)
+		// Do NOT log.Fatalf: a non-zero exit blocks the containerd shim from
+		// unmounting the /dev rbind, which wedges shutdown for ~20 minutes.
+		// Un-exported pools are recovered next boot by `zpool import -fal`.
+		log.Printf("zfs-service: zpool export did not finish within %s: %v; leaving pools for boot-time import\n", timeout, err)
 	}
 }


### PR DESCRIPTION
## What

Bound the shutdown `zpool export -a` in the `zfs-service` extension with a context timeout and a clean exit, configurable via `ZFS_EXPORT_TIMEOUT`:

- **default `8s`** (unset): bound the export under Talos's 10s grace;
- `ZFS_EXPORT_TIMEOUT=<duration>`: use that bound instead;
- `ZFS_EXPORT_TIMEOUT=0`: skip the export entirely (pre-v1.13 behavior).

On timeout or error the service logs and **exits 0** (instead of `log.Fatalf`) so the containerd shim can unmount `/dev` cleanly; un-exported pools are recovered next boot by the existing `zpool import -fal`.

Refs #1085.

## Why

v1.13.0 (#1028, @gjabell) added `zpool export -a` at shutdown so that, for **LUKS-on-ZFS**, the backing device is released and `cryptsetup close` stops looping so an upgrade can finish (talos#9307 / #8800). It is a blocking `cmd.Run()` with `log.Fatalf` on error.

Talos gives extension services a **fixed 10s SIGTERM→SIGKILL grace** (`GracefulShutdownTimeout` in `internal/app/machined/pkg/system/runner/runner.go`), with **no machine-config knob** to raise it. On busy pools the export overruns the grace → the **service** is SIGKILLed mid-export → the containerd shim hangs ~20 min cleaning up the extension's `/dev` rshared-rbind mount (still referencing zvol nodes). v1.12.x ran `zfs unmount -au` only (no export) and never wedged.

Bounding the export below the grace lets the service **exit cleanly in time**, so Talos's unmount phases run in order. The bound is best-effort: if the export can't finish under the grace, the pool is simply left for the next boot's `zpool import -fal`.

Topology note: #1028's case is LUKS *under* ZFS — the export releases the device `cryptsetup` needs. The reported case is DRBD/LUKS *over* zvols (LINSTOR/Piraeus), where only raw disk sits under the pool, so the export releases nothing downstream and is just the step most likely to block. The configurable bound + `0`-skip serve both.

## How

`storage/zfs/zfs-service/main.go`: wrap the export in `context.WithTimeout` + `exec.CommandContext` with `cmd.WaitDelay = time.Second`; on timeout/error `log.Printf` and return (exit 0). Mirrors the in-repo `context` + `exec.CommandContext` + `WaitDelay` pattern from `nvidia-gpu/.../nvidia-fabricmanager-wrapper`.

Per @smira's review, the README docs for setting `ZFS_EXPORT_TIMEOUT` via an `ExtensionServiceConfig` are dropped for now (the optional-configuration story can be revisited separately); the env var stays in the code. **This PR is now a single-file change to `main.go`.**

## Default value (per the #1085 discussion)

Thanks @gjabell and @utkuozdemir. Since there's a hard 10s ceiling, the export is inherently best-effort, so this defaults to a **bounded 8s**: it fixes the wedge out-of-the-box for everyone, and @gjabell's fast LUKS-on-ZFS export completes well before it (no regression). 8s rather than ~9s to leave headroom under the 10s grace for `zfs unmount -au`, the 1s `WaitDelay`, and the process exit — at 9s + 1s WaitDelay the service itself risks being SIGKILLed, which is the very thing we're avoiding. `ZFS_EXPORT_TIMEOUT=0` remains a full opt-out. (A plain on/off toggle would be equivalent to `8s`/`0` here — the duration just also lets operators tune the bound.)

## Scope notes

Only `zpool export -a` is bounded. The preceding `zfs unmount -au` is still an unbounded blocking `cmd.Run()` + `log.Fatalf`; if a busy pool hangs *unmount* it could wedge similarly — happy to bound it the same way if wanted.

## Backport

Requested for **release-1.13 (v1.13.x)** — the regression landed in v1.13.0 (`f89b232`). Understood that contributors don't PR release branches directly and @smira batches these into the next `backports: for v1.13.x`.

## Validation status

Validated on a disposable single-node QEMU Talos **v1.13.3** cluster running this patched extension, with a non-trivial pool — 64 zvols → 64 `/dev` zvol device nodes in the extension's `/dev` rbind; the pool's real `zpool export -a` measures ~1.4s:

| scenario | observed behavior | reboot |
|---|---|---|
| **export exceeds the bound** (`ZFS_EXPORT_TIMEOUT=200ms`) | logs `zpool export did not finish within 200ms: signal: killed; leaving pools for boot-time import`; exits 0; `ext-zfs-service` Finished **1.52s** after SIGTERM | clean, **59.8s** |
| **export completes within the bound** (the 8s default easily clears a ~1.4s export) | export runs to completion; exits 0; Finished **1.67s** after SIGTERM | clean, **59.9s** |
| **skip** (`ZFS_EXPORT_TIMEOUT=0`) | logs `ZFS_EXPORT_TIMEOUT=0, skipping zpool export`; pool left **imported** | immediate clean exit |

In every case `ext-zfs-service` reached `Finished: Service finished successfully` within the fixed 10s grace, and the shutdown's `unmountPodMounts` / `unmountSystemDiskBindMounts` / `unmountSystem` phases each completed in **single-digit milliseconds** — i.e. the containerd `/dev`-rbind cleanup that wedges ~20 min in the bug proceeds cleanly.

Honest limits: single-node KVM lab with a file-vdev pool, not the prod DRBD/Piraeus stack. It exercises the real `ext-zfs-service` and the real containerd `/dev`-rbind cleanup, but does not 1:1 reproduce DRBD's kernel-pinning of zvols. The interruptible export here was reaped by SIGKILL within the bound; a `zpool` stuck in an uninterruptible D-state ioctl would not be reaped faster — the change is then strictly no worse than today.
