### PR TITLE
feat: Add dvb-usb-dvbsky extension for MyGica T230C DVB-T/T2/C USB stick

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -17,6 +17,7 @@ spec:
     - drbd
     - dvb-cx23885
     - dvb-m88ds3103
+    - dvb-usb-dvbsky
     - ecr-credential-provider
     - fuse3
     - gasket-driver

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,6 +23,7 @@ If the field is marked as `Needs Maintainer`, it means that the package is curre
 | drbd                                      | Needs Maintainer   | NA                                                                                       |
 | dvb-cx23885                               | Skyler Mäntysaari  | [samip5](https://github.com/samip5)                                                      |
 | dvb-m88ds3103                             | Yehia Amer         | [yehia2amer](https://github.com/yehia2amer)                                              |
+| dvb-usb-dvbsky                            | Rokoucha           | [rokoucha](https://github.com/rokoucha)                                                  |
 | ecr-credential-provider                   | Florian Ströger    | [Preisschild](https://github.com/Preisschild)                                            |
 | fuse3                                     | Sidero Labs        | NA                                                                                       |
 | gasket-driver                             | Sidero Labs        | NA                                                                                       |

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ TARGETS += ctr
 TARGETS += drbd
 TARGETS += dvb-cx23885
 TARGETS += dvb-m88ds3103
+TARGETS += dvb-usb-dvbsky
 TARGETS += ecr-credential-provider
 TARGETS += fuse3
 TARGETS += gasket-driver

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ tiers based on support level:
 | ---- | ---- | ----- | ------- | ----------- |
 | [dvb-cx23885](dvb/cx23885) | :white_large_square: contrib | [ghcr.io/siderolabs/dvb-cx23885](https://github.com/siderolabs/extensions/pkgs/container/dvb-cx23885) | `VERSION` |  This system extension provides the dvb kernel modules required for Hauppage WinTV-quadHD PCIe tuner built against a specific Talos version. Includes the firmware required. |
 | [dvb-m88ds3103](dvb/dvb-m88ds3103) | :white_large_square: contrib | [ghcr.io/siderolabs/dvb-m88ds3103](https://github.com/siderolabs/extensions/pkgs/container/dvb-m88ds3103) | `VERSION` |  This system extension provides the dvb-demod-m88ds3103.fw firmware for DVB-S/S2 PCIe cards like DVBSky S952. It is intended to be used as a dependency on existing DVB driver extension dvb-cx23885 that provides the necessary kernel modules. |
+| [dvb-usb-dvbsky](dvb/dvb-usb-dvbsky) | :white_large_square: contrib | [ghcr.io/siderolabs/dvb-usb-dvbsky](https://github.com/siderolabs/extensions/pkgs/container/dvb-usb-dvbsky) | `VERSION` |  This system extension provides the dvb kernel modules required for DVBSky USB DVB devices, including the MyGica T230C DVB-T/T2/C USB stick built against a specific Talos version. Includes the firmware required. |
 
 ### Miscellaneous
 

--- a/dvb/dvb-usb-dvbsky/README.md
+++ b/dvb/dvb-usb-dvbsky/README.md
@@ -1,0 +1,16 @@
+# dvb-usb-dvbsky system extension
+
+## Installation
+
+See [Installing Extensions](https://github.com/siderolabs/extensions#installing-extensions).
+
+## Usage
+
+Enable the `dvb_usb_dvbsky` module in Talos machine config to enable the tuner.
+
+```yaml
+machine:
+  kernel:
+    modules:
+      - name: dvb_usb_dvbsky
+```

--- a/dvb/dvb-usb-dvbsky/files/dvb.conf
+++ b/dvb/dvb-usb-dvbsky/files/dvb.conf
@@ -1,0 +1,2 @@
+blacklist dvb_usb_dvbsky
+blacklist dvb_core

--- a/dvb/dvb-usb-dvbsky/files/modules.txt
+++ b/dvb/dvb-usb-dvbsky/files/modules.txt
@@ -1,0 +1,11 @@
+modules.order
+modules.builtin
+modules.builtin.modinfo
+kernel/drivers/media/rc/rc-core.ko
+kernel/drivers/media/dvb-core/dvb-core.ko
+kernel/drivers/i2c/i2c-mux.ko
+kernel/drivers/media/dvb-frontends/m88ds3103.ko
+kernel/drivers/media/dvb-frontends/si2168.ko
+kernel/drivers/media/tuners/si2157.ko
+kernel/drivers/media/usb/dvb-usb-v2/dvb_usb_v2.ko
+kernel/drivers/media/usb/dvb-usb-v2/dvb-usb-dvbsky.ko

--- a/dvb/dvb-usb-dvbsky/manifest.yaml.tmpl
+++ b/dvb/dvb-usb-dvbsky/manifest.yaml.tmpl
@@ -1,0 +1,11 @@
+version: v1alpha1
+metadata:
+  name: dvb-usb-dvbsky
+  version: "{{ .VERSION }}"
+  author: Rokoucha
+  description: |
+    [{{ .TIER }}] This system extension provides the dvb kernel modules required for DVBSky USB DVB devices, including the MyGica T230C DVB-T/T2/C USB stick built against a specific Talos version.
+    Includes the firmware required.
+  compatibility:
+    talos:
+      version: ">= v1.14.0"

--- a/dvb/dvb-usb-dvbsky/pkg.yaml
+++ b/dvb/dvb-usb-dvbsky/pkg.yaml
@@ -1,0 +1,53 @@
+name: dvb-usb-dvbsky
+variant: scratch
+shell: /bin/bash
+dependencies:
+  - stage: base
+  - stage: v4l-uvc-drivers
+  # The pkgs version for a particular release of Talos as defined in
+  # https://github.com/siderolabs/talos/blob/<talos version>/pkg/machinery/gendata/data/pkgs
+  - image: "{{ .BUILD_ARG_PKGS_PREFIX }}/kernel:{{ .BUILD_ARG_PKGS }}"
+steps:
+  - sources:
+      - url: https://raw.githubusercontent.com/osmc/dvb-firmware-osmc/master/dvb-demod-si2168-d60-01.fw
+        destination: dvb-demod-si2168-d60-01.fw
+        sha256: 753e338163d10244837a2fa4ad1258e1f270e3040e21ffa574609814943437c9
+        sha512: 25d3f6ac7f194b39b7cde7a21abd4acea2fe62fd86e2329010d679537fac83f4b0ef40cb3fafe110bc1f922941a14f111b15c1142267ac69b779a8c093f7627d
+      - url: https://raw.githubusercontent.com/osmc/dvb-firmware-osmc/master/dvb-tuner-si2141-a10-01.fw
+        destination: dvb-tuner-si2141-a10-01.fw
+        sha256: 29cf0b0d20a3040f8e59b0ed548e9d3d54eda0b2d2869708f7bcee9d7cbf7e34
+        sha512: cbcbc2b9b5b1735e049f2dd57b01fed153a1ed173054ef324ce779f0ac98cbead7bc3883d3f69c2e4e4339a15a13ebaec2168c31e3a1c0982ecd86d9640279b9
+    prepare:
+      - |
+        mkdir -p /rootfs
+      # {{ if eq .ARCH "x86_64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+    install:
+      - |
+        export KERNELRELEASE=$(find /usr/lib/modules -type d -name "*-talos" -exec basename {} \+)
+
+        mkdir -p /rootfs
+
+        xargs -a /pkg/files/modules.txt -I {} install -D /usr/lib/modules/${KERNELRELEASE}/{} /rootfs/usr/lib/modules/${KERNELRELEASE}/{}
+        depmod -b /rootfs/usr ${KERNELRELEASE}
+      - |
+        mkdir -p /rootfs/usr/local/lib/modprobe.d
+        cp /pkg/files/dvb.conf /rootfs/usr/local/lib/modprobe.d/dvb-usb-dvbsky.conf
+      - |
+        mkdir -p /rootfs/usr/lib/firmware
+        cp dvb-demod-si2168-d60-01.fw /rootfs/usr/lib/firmware
+        cp dvb-tuner-si2141-a10-01.fw /rootfs/usr/lib/firmware
+    test:
+      - |
+        # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping
+        find /rootfs/usr/lib/modules -name '*.ko' -exec grep -FL '~Module signature appended~' {} \+
+      - |
+        mkdir -p /extensions-validator-rootfs
+        cp -r /rootfs/ /extensions-validator-rootfs/rootfs
+        cp /pkg/manifest.yaml /extensions-validator-rootfs/manifest.yaml
+        /extensions-validator validate --rootfs=/extensions-validator-rootfs --pkg-name="${PKG_NAME}"
+    # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /

--- a/dvb/dvb-usb-dvbsky/vars.yaml
+++ b/dvb/dvb-usb-dvbsky/vars.yaml
@@ -1,0 +1,2 @@
+VERSION: "{{ .BUILD_ARG_TAG }}"
+TIER: "contrib"


### PR DESCRIPTION
This PR adds the `dvb-usb-dvbsky` extension for DVBSky USB DVB devices, including the MyGica T230C DVB-T/T2/C USB stick.

The required kernel modules were enabled in siderolabs/pkgs#1572.
This extension packages the DVB USB modules and firmware needed by these devices, following the existing `dvb-cx23885` extension pattern.

The module can be enabled with the following Talos machine config:

```yaml
machine:
  kernel:
    modules:
      - name: dvb_usb_dvbsky
```

Built successfully with `PKGS=v1.14.0-alpha.0-71-gaa9fe00`

Note: The module set was checked on an Arch Linux host with a physical MyGica T230C device, which was recognised successfully.

```
si2157                 32768  2
si2168                 28672  2
dvb_usb_dvbsky         32768  2
dvb_usb_v2             53248  1 dvb_usb_dvbsky
m88ds3103              45056  1 dvb_usb_dvbsky
dvb_core              217088  4 dvb_usb_v2,dvb_usb_dvbsky
videobuf2_vmalloc      20480  1 dvb_core
videobuf2_common       94208  3 videobuf2_vmalloc,dvb_core,videobuf2_memops
i2c_mux                16384  2 m88ds3103,si2168
mc                     90112  4 si2157,dvb_usb_v2,dvb_core,videobuf2_common
```
