### PR TITLE
chore(drm/xe): ship i915 firmware directory

### DIFF
--- a/drm/xe/pkg.yaml
+++ b/drm/xe/pkg.yaml
@@ -20,6 +20,7 @@ steps:
       - |
         mkdir -p /rootfs/usr/lib/firmware
         cp -R -p /usr/lib/firmware/xe /rootfs/usr/lib/firmware
+        cp -R -p /usr/lib/firmware/i915 /rootfs/usr/lib/firmware
   - test:
       - |
         # https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html#signed-modules-and-stripping


### PR DESCRIPTION
The "xe" driver needs i915 DMC firmware (e.g. "i915/bmg_dmc.bin") to enable runtime power management on Intel Arc/Battlemage GPUs. Copy the full i915 firmware directory into the xe extension rootfs so the driver can find it without requiring the separate i915 extension.