### PR TITLE
feat(kata-containers): add QEMU hypervisor handler

### DIFF
--- a/container-runtime/kata-containers/11-kata-qemu.part
+++ b/container-runtime/kata-containers/11-kata-qemu.part
@@ -1,0 +1,6 @@
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.kata-qemu]
+  runtime_type = "io.containerd.kata.v2"
+  privileged_without_host_devices = true
+  pod_annotations = ["io.katacontainers.*"]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.kata-qemu.options]
+  ConfigPath = "/usr/local/share/kata-containers/configuration-qemu.toml"

--- a/container-runtime/kata-containers/README.md
+++ b/container-runtime/kata-containers/README.md
@@ -6,6 +6,17 @@ See [Installing Extensions](https://github.com/siderolabs/extensions#installing-
 
 ## Usage
 
+The extension registers two containerd runtime handlers, selected per-workload
+with a `RuntimeClass`:
+
+| handler     | hypervisor          | notes                                                                  |
+| ----------- | ------------------- | ---------------------------------------------------------------------- |
+| `kata`      | Cloud Hypervisor    | fast boot, low overhead                                                |
+| `kata-qemu` | QEMU                | on x86-64, exposes the host CPU virt flag to the guest for nested VMs  |
+
+Both handlers share the same guest kernel and rootfs image and differ only in
+the VMM binary and its configuration.
+
 ## Testing
 
 Apply the following manifest to run nginx pod using Kata Containers:
@@ -38,4 +49,36 @@ The pod should be up and running:
 $ kubectl get pods
 NAME           READY   STATUS    RESTARTS   AGE
 nginx-kata     1/1     Running   0          40s
+```
+
+To use the QEMU hypervisor instead, select the `kata-qemu` handler:
+
+```yaml
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-qemu
+handler: kata-qemu
+overhead:
+    podFixed:
+        memory: "160Mi"
+        cpu: "250m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-kata-qemu
+spec:
+  runtimeClassName: kata-qemu
+  containers:
+  - name: nginx
+    image: nginx
+```
+
+On x86-64, confirm the guest sees the CPU virtualization flag (required for
+nested VMs; not available on arm64, where the guest boots without EL2):
+
+```bash
+$ kubectl exec nginx-kata-qemu -- grep -m1 -o -E 'vmx|svm' /proc/cpuinfo
+vmx
 ```

--- a/container-runtime/kata-containers/pkg.yaml
+++ b/container-runtime/kata-containers/pkg.yaml
@@ -61,6 +61,40 @@ steps:
 
         mkdir -p /rootfs/usr/local/share/kata-containers
         cp /pkg/configuration.toml /rootfs/usr/local/share/kata-containers/
+      - |
+        cd kata-static
+
+        qemu={{ if eq .ARCH "aarch64" }}qemu-system-aarch64{{ else }}qemu-system-x86_64{{ end }}
+        cp ./opt/kata/bin/${qemu} /rootfs/usr/local/bin/${qemu}
+        strip /rootfs/usr/local/bin/${qemu}
+
+        mkdir -p /rootfs/usr/local/share/kata-qemu
+        cp -a ./opt/kata/share/kata-qemu/qemu /rootfs/usr/local/share/kata-qemu/qemu
+        rm -f /rootfs/usr/local/share/kata-qemu/qemu/edk2-*.fd
+        rm -rf /rootfs/usr/local/share/kata-qemu/qemu/firmware
+        # ROMs for platforms kata's q35/virt machines never use (hppa, ppc, s390, arm boards)
+        rm -f /rootfs/usr/local/share/kata-qemu/qemu/{hppa-firmware*.img,s390-*.img,slof.bin,vof*.bin,qemu_vga.ndrv,pnv-pnor.bin,*_bootrom.bin,qemu-nsis.bmp}
+
+        # kata builds QEMU with --disable-relocatable, so the firmware search path is
+        # hardcoded to /opt/kata/share/kata-qemu/qemu. QEMU still consults
+        # <exec_dir>/qemu-bundle/<compiled path> first; route that back to the datadir
+        mkdir -p /rootfs/usr/local/bin/qemu-bundle/opt/kata/share/kata-qemu
+        ln -s ../../../../../../share/kata-qemu/qemu /rootfs/usr/local/bin/qemu-bundle/opt/kata/share/kata-qemu/qemu
+        # {{ if eq .ARCH "aarch64" }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+        mkdir -p /rootfs/usr/local/share/aavmf
+        cp ./opt/kata/share/aavmf/AAVMF_CODE.fd /rootfs/usr/local/share/aavmf/AAVMF_CODE.fd
+        # {{ end }} This in fact is YAML comment, but Go templating instruction is evaluated by bldr
+
+        # AAVMF_VARS.fd is not shipped: kata ignores firmware_volume for
+        # non-confidential guests, so blank it instead of pointing at a missing file
+        mkdir -p /rootfs/usr/local/share/kata-containers
+        sed -e 's|/opt/kata|/usr/local|g' \
+          -e 's|^firmware_volume = .*|firmware_volume = ""|' \
+          ./opt/kata/share/defaults/kata-containers/configuration-qemu.toml \
+          > /rootfs/usr/local/share/kata-containers/configuration-qemu.toml
+
+        mkdir -p /rootfs/etc/cri/conf.d
+        cp /pkg/11-kata-qemu.part /rootfs/etc/cri/conf.d/11-kata-qemu.part
     test:
       - |
         mkdir -p /extensions-validator-rootfs

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -49,6 +49,12 @@ soci-snapshotter: v0.14.1
 wasmedge: 0.6.1
 """
 
+[notes.kata]
+    title = "Kata Containers"
+    description = """\
+Kata Containers now has support for the `kata-qemu` runtime handler which uses QEMU instead of Cloud Hypervisor for virtualization.
+"""
+
 [make_deps]
 
     [make_deps.tools]


### PR DESCRIPTION
Hi 👋 

This adds a `kata-qemu` containerd runtime handler alongside the existing Cloud Hypervisor one, selectable per-workload with a `RuntimeClass`.

**Why:** I run GitHub Actions runners on-cluster, and some CI jobs boot full VMs with QEMU (e.g. e2e tests that spin up a Talos cluster). Today that forces the runner pod to be fully privileged on the host kernel. The goal is to run those jobs inside a Kata VM instead, so the privilege stays behind a real VM boundary - but that requires nested virtualization inside the Kata guest. Cloud Hypervisor does not expose the CPU virtualization flag to the guest, so the existing `kata` handler can't do this; QEMU with `-cpu host` does (on x86-64).

The workflow boots a 3-node Talos cluster with the QEMU provisioner:

```bash
sudo -E "$(mise which talosctl)" cluster create qemu \
  --name "$cluster" \
  --cidr 10.5.0.0/24 \
  --schematic-id "$schematic" \
  --controlplanes 1 \
  --workers 2 \
  --memory-workers 5GiB \
  --disks "virtio:8GiB,virtio:${MIROIR_E2E_DISK_SIZE:-20GiB}" \
  --config-patch @deploy/e2e/talos-patch.yaml \
  --talosconfig-destination "$TALOSCONFIG"
```

**Size impact (x86-64):** I know there is a limitation so I wanted to give some data on the size difference this would be adding. Stripped `qemu-system-x86_64` (~30MB) plus its pruned datadir (<1MB after removing firmware for platforms kata never emulates); measured on the assembled extension rootfs:

| | uncompressed | squashfs (zstd) |
| --- | --- | --- |
| before | ~386MB | ~74MiB |
| after | ~416MB | ~78.7MiB |

**Question:** would you prefer this as a separate system extension (e.g. `kata-containers-qemu`) instead of bundling QEMU into `kata-containers`? Happy to split it out.