### PR TITLE
chore: replace gnu mirror

### DIFF
--- a/misc/glibc/pkg.yaml
+++ b/misc/glibc/pkg.yaml
@@ -17,7 +17,7 @@ steps:
       LD_LINUX_X86_64: ld-linux-x86-64.so.2
       LD_LINUX_AARCH64: ld-linux-aarch64.so.1
     sources:
-      - url: https://ftpmirror.gnu.org/gnu/glibc/glibc-{{ .GLIBC_VERSION }}.tar.xz
+      - url: https://ftp.gnu.org/gnu/glibc/glibc-{{ .GLIBC_VERSION }}.tar.xz
         destination: glibc.tar.xz
         sha256: {{ .GLIBC_SHA256 }}
         sha512: {{ .GLIBC_SHA512 }}


### PR DESCRIPTION
ftpmirror.gnu.org is down so replace it with ftp.gnu.org

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
