### PR TITLE
fix: preserve open-iscsi node record compatibility

### DIFF
--- a/storage/iscsi-tools/patches/node-reopen-log-freq-compat.patch
+++ b/storage/iscsi-tools/patches/node-reopen-log-freq-compat.patch
@@ -1,0 +1,58 @@
+diff --git a/libopeniscsiusr/idbm.c b/libopeniscsiusr/idbm.c
+index 783c7f5..ac51340 100644
+--- a/libopeniscsiusr/idbm.c
++++ b/libopeniscsiusr/idbm.c
+@@ -1118,9 +1118,12 @@ static void _idbm_node_rec_link(struct iscsi_node *node, struct idbm_rec *recs,
+ 	_rec_int_o2(SESSION_SCAN, recs, node, session.scan, IDBM_SHOW, "manual",
+ 		    "auto", num, _CAN_MODIFY);
+ 	_rec_int64(SESSION_REOPEN_MAX, recs, node, session.reopen_max, IDBM_SHOW, num,
+ 		   _CAN_MODIFY);
+-	_rec_int64(SESSION_REOPEN_LOG_FREQ, recs, node, session.sess_reopen_log_freq, IDBM_SHOW, num,
++	_rec_int64(SESSION_REOPEN_LOG_FREQ_LEGACY, recs, node,
++		   session.sess_reopen_log_freq, IDBM_SHOW, num, _CAN_MODIFY);
++	_rec_int64(SESSION_REOPEN_LOG_FREQ, recs, node,
++		   session.sess_reopen_log_freq, IDBM_HIDE, num,
+ 		   _CAN_MODIFY);
+ 
+ 	_rec_str(CONN_ADDR, recs, node, conn.address, IDBM_SHOW, num,
+ 		 _CANNOT_MODIFY);
+diff --git a/libopeniscsiusr/idbm_fields.h b/libopeniscsiusr/idbm_fields.h
+index 6d26126..439551c 100644
+--- a/libopeniscsiusr/idbm_fields.h
++++ b/libopeniscsiusr/idbm_fields.h
+@@ -138,6 +138,7 @@
+ #define SESSION_ERL		"node.session.iscsi.ERL"
+ #define SESSION_SCAN		"node.session.scan"
+ #define SESSION_REOPEN_MAX	"node.session.reopen_max"
++#define SESSION_REOPEN_LOG_FREQ_LEGACY "node.session.conn_reopen_log_freq"
+ #define SESSION_REOPEN_LOG_FREQ "node.session.sess_reopen_log_freq"
+ 
+ /* connections fields */
+diff --git a/usr/idbm.c b/usr/idbm.c
+index 8b20f44..72e4f9e 100644
+--- a/usr/idbm.c
++++ b/usr/idbm.c
+@@ -526,8 +526,10 @@ void idbm_recinfo_node(node_rec_t *r, recinfo_t *ri)
+ 			 num, 1);
+ 	__recinfo_int(SESSION_REOPEN_MAX, ri, r,
+ 			session.reopen_max, IDBM_SHOW, num, 1);
++	__recinfo_int(SESSION_REOPEN_LOG_FREQ_LEGACY, ri, r,
++			session.sess_reopen_log_freq, IDBM_SHOW, num, 1);
+ 	__recinfo_int(SESSION_REOPEN_LOG_FREQ, ri, r,
+-			session.sess_reopen_log_freq, IDBM_SHOW, num, 1);
++			session.sess_reopen_log_freq, IDBM_HIDE, num, 1);
+ 
+ 	for (i = 0; i < ISCSI_CONN_MAX; i++) {
+ 		char key[NAME_MAXVAL];
+diff --git a/usr/idbm_fields.h b/usr/idbm_fields.h
+index 9fd681c..59e0250 100644
+--- a/usr/idbm_fields.h
++++ b/usr/idbm_fields.h
+@@ -48,6 +48,7 @@
+ #define SESSION_ERL		"node.session.iscsi.ERL"
+ #define SESSION_SCAN		"node.session.scan"
+ #define SESSION_REOPEN_MAX	"node.session.reopen_max"
++#define SESSION_REOPEN_LOG_FREQ_LEGACY "node.session.conn_reopen_log_freq"
+ #define SESSION_REOPEN_LOG_FREQ "node.session.sess_reopen_log_freq"
+ 
+ /* connections fields */

--- a/storage/iscsi-tools/pkg.yaml
+++ b/storage/iscsi-tools/pkg.yaml
@@ -18,6 +18,7 @@ steps:
         patch -p1 < /pkg/patches/musl-fixes.patch
         patch -p1 < /pkg/patches/dont-use-lib64.patch
         patch -p1 < /pkg/patches/remove-werror.patch
+        patch -p1 < /pkg/patches/node-reopen-log-freq-compat.patch
     build:
       - |
         export PKG_CONFIG_PATH=/usr/lib/pkgconfig
@@ -52,6 +53,46 @@ steps:
 
         cp /pkg/iscsid.yaml /rootfs/usr/local/etc/containers/
     test:
+      - |
+        test_root=/var/lib/iscsi/nodes
+        legacy_target=iqn.2000-01.test:legacy-record
+        current_target=iqn.2000-01.test:current-record
+
+        legacy_record=${test_root}/${legacy_target}/127.0.0.1,3260,1/default
+        current_record=${test_root}/${current_target}/127.0.0.2,3260,1/default
+
+        mkdir -p "$(dirname "${legacy_record}")" "$(dirname "${current_record}")" /etc/iscsi
+        ln -s "${test_root}" /etc/iscsi/nodes
+
+        printf '%s\n' \
+          "node.name = ${legacy_target}" \
+          'node.tpgt = 1' \
+          'iface.iscsi_ifacename = default' \
+          'node.session.scan = auto' \
+          'node.session.conn_reopen_log_freq = 1' \
+          'node.conn[0].address = 127.0.0.1' \
+          'node.conn[0].port = 3260' >"${legacy_record}"
+        printf '%s\n' \
+          "node.name = ${current_target}" \
+          'node.tpgt = 1' \
+          'iface.iscsi_ifacename = default' \
+          'node.session.scan = auto' \
+          'node.session.sess_reopen_log_freq = 1' \
+          'node.conn[0].address = 127.0.0.2' \
+          'node.conn[0].port = 3260' >"${current_record}"
+
+        output/iscsiadm -m node -T "${legacy_target}" -p 127.0.0.1:3260 -o show >/dev/null
+        output/iscsiadm -m node -T "${current_target}" -p 127.0.0.2:3260 -o show >/dev/null
+
+        output/iscsiadm -m node -T "${current_target}" -p 127.0.0.2:3260 \
+          -o update -n node.session.sess_reopen_log_freq -v 2
+
+        grep -q '^node.session.conn_reopen_log_freq = 2$' "${current_record}"
+        test "$(grep -c '^node.session.sess_reopen_log_freq' "${current_record}")" -eq 0
+
+        rm -rf /var/lib/iscsi
+        rm -f /etc/iscsi/nodes
+        rmdir /etc/iscsi
       - |
         mkdir -p /extensions-validator-rootfs
         cp -r /rootfs/ /extensions-validator-rootfs/rootfs


### PR DESCRIPTION
Open-iSCSI 2.1.12 renamed a persisted node parameter without an alias, so its parser rejects records written by 2.1.11 and breaks iSCSI node enumeration.

Accept both spellings in both IDBM paths and serialize the legacy name so upgrades and rollbacks remain readable. Test mixed databases and record rewriting during the package build.

See: https://github.com/open-iscsi/open-iscsi/issues/540

Fixes: #1182