### PR TITLE
fix: drop multipath dependency on cri

### DIFF
--- a/storage/multipath-tools/multipathd.yaml
+++ b/storage/multipath-tools/multipathd.yaml
@@ -57,6 +57,5 @@ depends:
       - etcfiles
   - service: udevd
   - path: /dev/mapper/control
-  - service: cri
   # - configuration: true
 restart: always


### PR DESCRIPTION
It's not required, as it doesn't use anything from /var.

Fixes #1210

I'll test this once merged with netapp Test from Talos side.