### PR TITLE
fix: update CRI configs for version 4

### DIFF
--- a/container-runtime/gvisor-debug/11-gvisor-debug.part
+++ b/container-runtime/gvisor-debug/11-gvisor-debug.part
@@ -1,4 +1,2 @@
 [debug]
   level = "debug"
-[plugins."io.containerd.runtime.v1.linux"]
-  shim_debug = true


### PR DESCRIPTION
containerd propagates its own log level to the shims, so `[debug] level` is enough to get shim debug logging; the `io.containerd.runtime.v1.linux` plugin (and its `shim_debug` option) no longer exists in containerd 2.x.