### PR TITLE
fix: nvidia vulkan paths

### DIFF
--- a/hack/test/exceptions-amd64.yaml
+++ b/hack/test/exceptions-amd64.yaml
@@ -704,7 +704,7 @@
   files:
     - rootfs/etc/cri/conf.d/10-nvidia-container-runtime.part
     - rootfs/etc/vulkan/icd.d/nvidia_icd.json
-    - rootfs/etc/vulkan/icd.d/nvidia_layers.json
+    - rootfs/etc/vulkan/implicit_layer.d/nvidia_layers.json
     - rootfs/etc/vulkansc/icd.d/nvidia_icd_vksc.json
     - rootfs/usr/bin/nvidia-cdi-hook
     - rootfs/usr/bin/nvidia-ctk

--- a/hack/test/exceptions-arm64.yaml
+++ b/hack/test/exceptions-arm64.yaml
@@ -391,7 +391,7 @@
   files:
     - rootfs/etc/cri/conf.d/10-nvidia-container-runtime.part
     - rootfs/etc/vulkan/icd.d/nvidia_icd.json
-    - rootfs/etc/vulkan/icd.d/nvidia_layers.json
+    - rootfs/etc/vulkan/implicit_layer.d/nvidia_layers.json
     - rootfs/usr/bin/nvidia-cdi-hook
     - rootfs/usr/bin/nvidia-ctk
     - rootfs/usr/bin/nvidia-modprobe

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/lts/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/lts/pkg.yaml
@@ -81,6 +81,11 @@ steps:
           --no-systemd \
           # {{ if eq .ARCH "x86_64" }}--no-install-compat32-libs{{ end }}
 
+        # Destination overrides flatten the source path to its basename, so restore the
+        # implicit layer path documented by the NVIDIA driver README.
+        mkdir -p /rootfs/etc/vulkan/implicit_layer.d
+        mv /rootfs/etc/vulkan/icd.d/nvidia_layers.json /rootfs/etc/vulkan/implicit_layer.d/
+
         # TODO: should we allow this in extension spec, cdi doesn't seem to check this files
         # --override-file-type-destination=CUDA_ICD:/rootfs/etc/OpenCL/vendors \
 

--- a/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/production/pkg.yaml
+++ b/nvidia-gpu/nvidia-container-toolkit/nvidia-pkgs/production/pkg.yaml
@@ -80,6 +80,11 @@ steps:
           --no-systemd \
           # {{ if eq .ARCH "x86_64" }}--no-install-compat32-libs{{ end }}
 
+        # Destination overrides flatten the source path to its basename, so restore the
+        # implicit layer path documented by the NVIDIA driver README.
+        mkdir -p /rootfs/etc/vulkan/implicit_layer.d
+        mv /rootfs/etc/vulkan/icd.d/nvidia_layers.json /rootfs/etc/vulkan/implicit_layer.d/
+
         # TODO: should we allow this in extension spec, cdi doesn't seem to check this files
         # --override-file-type-destination=CUDA_ICD:/rootfs/etc/OpenCL/vendors \
 


### PR DESCRIPTION
CDI still would detect the old path, but let's future proof.