### PR TITLE
fix: avoid virtqemud reconnect deadlock

### DIFF
--- a/hypervisors/libvirtd/virtqemud.yaml
+++ b/hypervisors/libvirtd/virtqemud.yaml
@@ -7,6 +7,9 @@ depends:
   - path: /etc/passwd
   - path: /etc/group
 container:
+  # Talos doesn't run systemd-machined; probing it over D-Bus blocks QEMU reconnect.
+  environment:
+    - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/libvirt/no-dbus
   entrypoint: /usr/local/sbin/virtqemud
   args:
     - --timeout


### PR DESCRIPTION
Talos provides a system D-Bus socket but does not run systemd-machined. virtqemud blocks while probing that unavailable service during QEMU domain reconnect, leaving management RPCs hung after a daemon restart.

Point virtqemud at an absent bus socket so libvirt immediately treats systemd integration as unavailable.